### PR TITLE
Fix release script failure when GitHub release does not exist

### DIFF
--- a/publish_release.ps1
+++ b/publish_release.ps1
@@ -55,9 +55,18 @@ try {
     # Check if release already exists using gh CLI
     # We allow the error stream to go to null, we just care about the exit code.
     # Note: running an external command like gh inside PowerShell updates $LASTEXITCODE
-    gh release view $version 2>&1 | Out-Null
+    $releaseExists = $false
+    try {
+        gh release view $version 2>&1 | Out-Null
+        if ($LASTEXITCODE -eq 0) {
+            $releaseExists = $true
+        }
+    } catch {
+        # If gh release view fails, it usually means the release doesn't exist.
+        # We proceed to create it.
+    }
 
-    if ($LASTEXITCODE -eq 0) {
+    if ($releaseExists) {
         Write-Warning "Release $version already exists. Skipping creation."
         exit 0
     }


### PR DESCRIPTION
Modified `publish_release.ps1` to handle the "release not found" error from the GitHub CLI gracefully. The `gh release view` command is now wrapped in a try/catch block, allowing the script to treat the exception as an indication that the release needs to be created, rather than a fatal error.

---
*PR created automatically by Jules for task [12204002301735887854](https://jules.google.com/task/12204002301735887854) started by @Rapscallion0*