### PR TITLE
Fix missing embedded launcher resource

### DIFF
--- a/SMS Search.csproj
+++ b/SMS Search.csproj
@@ -66,7 +66,7 @@
     </ProjectReference>
   </ItemGroup>
 
-  <Target Name="EmbedLauncher" BeforeTargets="CoreCompile">
+  <Target Name="EmbedLauncher" AfterTargets="ResolveReferences">
     <Message Text="Embedding SMS Search Launcher from Launcher/bin/$(Configuration)/SMSSearchLauncher.exe" Importance="high" />
     <Error Condition="!Exists('Launcher/bin/$(Configuration)/SMSSearchLauncher.exe')" Text="Launcher executable not found at Launcher/bin/$(Configuration)/SMSSearchLauncher.exe. Build Launcher project first." />
     <ItemGroup>


### PR DESCRIPTION
Fixed an issue where the `SMSSearchLauncher.exe` was not being embedded into the main application, causing a "Embedded launcher resource not found" error at runtime. This was due to the `EmbedLauncher` MSBuild target running too late in the build process (`BeforeTargets="CoreCompile"`). Moving it to `AfterTargets="ResolveReferences"` ensures the `EmbeddedResource` item is correctly registered and processed. Validated the fix by inspecting the generated assembly resources.

---
*PR created automatically by Jules for task [10551834269303429531](https://jules.google.com/task/10551834269303429531) started by @Rapscallion0*