### PR TITLE
Fix build errors in SMS Search project

### DIFF
--- a/SMS Search.csproj
+++ b/SMS Search.csproj
@@ -11,7 +11,13 @@
     <AssemblyName>SMSSearch</AssemblyName>
     <GenerateResourceUsePreserializedResources>true</GenerateResourceUsePreserializedResources>
     <ApplicationManifest>app.manifest</ApplicationManifest>
+    <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
   </PropertyGroup>
+
+  <Target Name="KillLauncher" BeforeTargets="Build" Condition="'$(OS)' == 'Windows_NT'">
+    <Exec Command="taskkill /F /IM &quot;SMS Search Launcher.exe&quot; 2&gt;nul || exit 0" />
+    <Exec Command="taskkill /F /IM &quot;SMSSearchLauncher.exe&quot; 2&gt;nul || exit 0" />
+  </Target>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <ShouldCreateLogs>True</ShouldCreateLogs>

--- a/Settings/LauncherSettings.cs
+++ b/Settings/LauncherSettings.cs
@@ -3,6 +3,7 @@ using System.Diagnostics;
 using System.Drawing;
 using System.IO;
 using System.Runtime.InteropServices;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Forms;
 using SMS_Search;


### PR DESCRIPTION
Resolved build errors preventing successful compilation.

1.  **File Locking:** Added a `PreBuild` target to `SMS Search.csproj` that kills `SMS Search Launcher.exe` and `SMSSearchLauncher.exe` if running. This releases file locks on DLLs in `bin/Debug` that were preventing the build from cleaning/overwriting files. This target is conditioned to run only on `Windows_NT` to prevent side effects on other platforms.
2.  **Duplicate Attribute:** Added `<GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>` to `SMS Search.csproj` to resolve `CS0579` (Duplicate 'global::System.Runtime.Versioning.TargetFrameworkAttribute' attribute).
3.  **Missing Namespace:** Added `using System.Threading;` to `Settings/LauncherSettings.cs` to resolve `CS0246` for `WaitHandleCannotBeOpenedException`.
4.  **Cleanup:** Verified no references to the removed `Launcher.csproj` remain in the solution.

---
*PR created automatically by Jules for task [1392195073065163146](https://jules.google.com/task/1392195073065163146) started by @Rapscallion0*