### PR TITLE
Fix startup crash in LauncherSettings by ensuring window handle exists before Invoke

### DIFF
--- a/Settings/LauncherSettings.cs
+++ b/Settings/LauncherSettings.cs
@@ -35,9 +35,6 @@ namespace SMS_Search.Settings
             _config = config;
             LoadSettings();
 
-            // Check for migration
-            CheckAndMigrateLegacy();
-
             UpdateLauncherStatusUI();
             WireUpEvents();
         }
@@ -45,6 +42,15 @@ namespace SMS_Search.Settings
         public LauncherSettings()
         {
             InitializeComponent();
+        }
+
+        protected override void OnLoad(EventArgs e)
+        {
+            base.OnLoad(e);
+            if (!DesignMode)
+            {
+                CheckAndMigrateLegacy();
+            }
         }
 
         public void Reload()


### PR DESCRIPTION
This change fixes a runtime `InvalidOperationException` that occurred when launching the application or opening settings. The error "Invoke or BeginInvoke cannot be called on a control until the window handle has been created" was caused by `LauncherSettings` attempting to invoke UI updates (via `CheckAndMigrateLegacy`) in its constructor, before the window handle was created. The logic has been moved to the `OnLoad` event to ensure the handle exists. I also investigated the user's build issue regarding the `Launcher` folder but found no references in the solution; I attempted to clean it up if it existed locally.

---
*PR created automatically by Jules for task [4992129292213269088](https://jules.google.com/task/4992129292213269088) started by @Rapscallion0*