### PR TITLE
Standardize configuration file name to SMSSearch_settings.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ SMS Search is a Windows Forms application designed to assist in searching and qu
 - **Custom SQL**: Execute custom SQL queries directly within the application.
 - **SQL Cleaner**: Utility to "clean" SQL queries by removing formatting and comments for easier reading or copying.
 - **Unarchive Tool**: Includes a helper form (`frmUnarchive`) for handling archived data.
-- **Configuration**: Customizable settings via `SMS Search_settings.json` (Database connection, UI preferences).
+- **Configuration**: Customizable settings via `SMSSearch_settings.json` (Database connection, UI preferences).
 - **Export/View**: Results are displayed in a DataGridView with sorting and resize capabilities.
 
 ## Prerequisites
@@ -31,7 +31,7 @@ SMS Search is a Windows Forms application designed to assist in searching and qu
 
 ## Configuration
 
-The application uses `SMS Search_settings.json` for configuration. If the file is missing or the connection fails, the configuration window will open on startup.
+The application uses `SMSSearch_settings.json` for configuration. If the file is missing or the connection fails, the configuration window will open on startup.
 
 **Key Configuration Sections:**
 - `[CONNECTION]`: Stores `SERVER` and `DATABASE` names.

--- a/Settings/frmConfig.cs
+++ b/Settings/frmConfig.cs
@@ -10,7 +10,7 @@ namespace SMS_Search.Settings
 {
     public partial class frmConfig : Form
     {
-        private ConfigManager config = new ConfigManager(Path.Combine(Application.StartupPath, "SMS Search_settings.json"));
+        private ConfigManager config = new ConfigManager(Path.Combine(Application.StartupPath, "SMSSearch_settings.json"));
         private Logfile log = new Logfile();
 
         private GeneralSettings generalSettings;
@@ -29,8 +29,8 @@ namespace SMS_Search.Settings
             base.StartPosition = FormStartPosition.Manual;
             base.Top = (Screen.PrimaryScreen.WorkingArea.Height - base.Height) / 2;
             base.Left = (Screen.PrimaryScreen.WorkingArea.Width - base.Width) / 2;
-            lblConfigFilePath.Text = Path.Combine(Application.StartupPath, "SMS Search_settings.json");
-            toolTip1.SetToolTip(lblConfigFilePath, Path.Combine(Application.StartupPath, "SMS Search_settings.json"));
+            lblConfigFilePath.Text = Path.Combine(Application.StartupPath, "SMSSearch_settings.json");
+            toolTip1.SetToolTip(lblConfigFilePath, Path.Combine(Application.StartupPath, "SMSSearch_settings.json"));
 
             InitializeUserControls();
         }
@@ -152,7 +152,7 @@ namespace SMS_Search.Settings
              if (MessageBox.Show("This will reset all settings to their default values (including Database connection).\nAre you sure?",
                  "Revert to Default", MessageBoxButtons.YesNo, MessageBoxIcon.Warning) == DialogResult.Yes)
              {
-                 string path = Path.Combine(Application.StartupPath, "SMS Search_settings.json");
+                 string path = Path.Combine(Application.StartupPath, "SMSSearch_settings.json");
                  try
                  {
                      if (File.Exists(path)) File.Delete(path);
@@ -178,7 +178,7 @@ namespace SMS_Search.Settings
 
         private void lblConfigFilePath_Click(object sender, EventArgs e)
         {
-            System.Diagnostics.Process.Start(Path.Combine(Application.StartupPath, "SMS Search_settings.json"));
+            System.Diagnostics.Process.Start(Path.Combine(Application.StartupPath, "SMSSearch_settings.json"));
         }
     }
 }

--- a/frmEula.cs
+++ b/frmEula.cs
@@ -16,7 +16,7 @@ namespace SMS_Search
 		private Label label1;
 		private Label label2;
 		private Panel panel1;
-		private static string ConfigFilePath = Path.Combine(Application.StartupPath, "SMS Search_settings.json");
+		private static string ConfigFilePath = Path.Combine(Application.StartupPath, "SMSSearch_settings.json");
 		private ConfigManager config = new ConfigManager(frmEula.ConfigFilePath);
 		protected override void Dispose(bool disposing)
 		{

--- a/frmUnarchive.cs
+++ b/frmUnarchive.cs
@@ -11,7 +11,7 @@ namespace SMS_Search
 {
 	public partial class frmUnarchive : Form
 	{
-		private static string ConfigFilePath = Path.Combine(Application.StartupPath, "SMS Search_settings.json");
+		private static string ConfigFilePath = Path.Combine(Application.StartupPath, "SMSSearch_settings.json");
 		private ConfigManager config = new ConfigManager(frmUnarchive.ConfigFilePath);
 		private Logfile log = new Logfile();
 


### PR DESCRIPTION
The application was experiencing a "split-brain" configuration issue where the main window read from `SMSSearch_settings.json`, but the configuration, EULA, and unarchive windows wrote to `SMS Search_settings.json`. This caused settings changes, particularly database connections, to be ignored by the main application, leading to connection errors. This change standardizes all forms to use `SMSSearch_settings.json`.

---
*PR created automatically by Jules for task [14428892188000456289](https://jules.google.com/task/14428892188000456289) started by @Rapscallion0*