### PR TITLE
Fix launcher migration loop and status reporting

### DIFF
--- a/Settings/LauncherSettings.cs
+++ b/Settings/LauncherSettings.cs
@@ -95,9 +95,9 @@ namespace SMS_Search.Settings
             string legacyPath = Path.Combine(Application.StartupPath, LegacyLauncherExe);
             string startupFolder = Environment.GetFolderPath(Environment.SpecialFolder.Startup);
             string oldShortcut = Path.Combine(startupFolder, "SMS Search Launcher.lnk"); // Very old
-            string legacyShortcut = Path.Combine(startupFolder, "SMSSearchLauncher.lnk"); // Recent old
+            // string legacyShortcut = Path.Combine(startupFolder, "SMSSearchLauncher.lnk"); // Recent old - matches current new shortcut name!
 
-            bool legacyExists = File.Exists(legacyPath) || File.Exists(oldShortcut) || File.Exists(legacyShortcut);
+            bool legacyExists = File.Exists(legacyPath) || File.Exists(oldShortcut);
 
             if (legacyExists)
             {
@@ -427,6 +427,15 @@ namespace SMS_Search.Settings
             {
                 _log.Logger(LogLevel.Info, "Starting Launcher");
                 Process.Start(targetPath, "--listener");
+
+                // Wait for it to start
+                int retries = 20; // 2 seconds
+                while (retries > 0)
+                {
+                    if (IsLauncherRunning()) break;
+                    System.Threading.Thread.Sleep(100);
+                    retries--;
+                }
             }
         }
 
@@ -540,26 +549,28 @@ namespace SMS_Search.Settings
             // Simplified check: just shortcut existence + isListener running?
 
             bool isRegistered = File.Exists(shortcutPath);
-
-            DrawStatusLight(isRegistered);
+            bool isRunning = IsLauncherRunning();
 
             if (isRegistered)
             {
                  btnRegister.Enabled = false;
                  btnUnregister.Enabled = true;
 
-                 if (IsLauncherRunning())
+                 if (isRunning)
                  {
                       lblLauncherStatus.Text = "Status: Registered - Service Running";
+                      DrawStatusLight(Color.Green);
                  }
                  else
                  {
                       lblLauncherStatus.Text = "Status: Registered - Service Stopped";
+                      DrawStatusLight(Color.Orange);
                  }
             }
             else
             {
                  lblLauncherStatus.Text = "Status: Not Registered";
+                 DrawStatusLight(Color.Red);
                  btnRegister.Enabled = true;
                  btnUnregister.Enabled = false;
             }


### PR DESCRIPTION
This PR addresses two issues with the background listener (Launcher) configuration:

1.  **Migration Loop:** The application was incorrectly identifying the valid new startup shortcut (`SMSSearchLauncher.lnk`) as a legacy artifact, triggering a migration process on every load. This check has been corrected to only flag the truly old `SMS Search Launcher.lnk` or the legacy executable.
2.  **Status Reporting:**
    *   **Race Condition:** When registering the service, the UI would often report "Service Stopped" immediately because it checked the status before the background process had finished initializing. A polling mechanism (up to 2 seconds) has been added to `StartLauncher` to wait for the service's mutex.
    *   **Visual Feedback:** The status light logic has been refined. Previously, it showed Green if the service was just *Registered*. Now, it shows Green only if Registered AND Running, Orange if Registered but Stopped, and Red if Not Registered.

---
*PR created automatically by Jules for task [1801668250654044293](https://jules.google.com/task/1801668250654044293) started by @Rapscallion0*