### PR TITLE
Fix Settings TreeView Resizing

### DIFF
--- a/Settings/frmConfig.Designer.cs
+++ b/Settings/frmConfig.Designer.cs
@@ -48,6 +48,7 @@ namespace SMS_Search.Settings
             this.splitConfig.Panel1.Controls.Add(this.tvSettings);
             this.splitConfig.Size = new System.Drawing.Size(584, 400);
             this.splitConfig.SplitterDistance = 150;
+            this.splitConfig.FixedPanel = System.Windows.Forms.FixedPanel.Panel1;
             this.splitConfig.TabIndex = 0;
             //
             // tvSettings


### PR DESCRIPTION
Set the FixedPanel property of the SplitContainer in `frmConfig` to `Panel1`. This prevents the navigation treeview from resizing when the main settings window is resized, while still allowing manual adjustment of the splitter.

---
*PR created automatically by Jules for task [3942321208049425659](https://jules.google.com/task/3942321208049425659) started by @Rapscallion0*