### PR TITLE
Move Environment controls to EnvironmentSettings panel

### DIFF
--- a/Settings/EnvironmentSettings.Designer.cs
+++ b/Settings/EnvironmentSettings.Designer.cs
@@ -1,4 +1,4 @@
-﻿namespace SMS_Search.Settings
+namespace SMS_Search.Settings
 {
     partial class EnvironmentSettings
     {
@@ -28,18 +28,133 @@
         /// </summary>
         private void InitializeComponent()
         {
+            this.components = new System.ComponentModel.Container();
+            this.lblStartTab = new System.Windows.Forms.Label();
+            this.cmbStartTab = new System.Windows.Forms.ComboBox();
+            this.lblStartupLocation = new System.Windows.Forms.Label();
+            this.cmbStartupLocation = new System.Windows.Forms.ComboBox();
+            this.chkAlwaysOnTop = new System.Windows.Forms.CheckBox();
+            this.chkShowInTray = new System.Windows.Forms.CheckBox();
+            this.chkMultiInstance = new System.Windows.Forms.CheckBox();
+            this.chkUnarchiveTarget = new System.Windows.Forms.CheckBox();
+            this.toolTip1 = new System.Windows.Forms.ToolTip(this.components);
             this.SuspendLayout();
             // 
+            // lblStartTab
+            //
+            this.lblStartTab.AutoSize = true;
+            this.lblStartTab.Location = new System.Drawing.Point(15, 18);
+            this.lblStartTab.Name = "lblStartTab";
+            this.lblStartTab.Size = new System.Drawing.Size(59, 13);
+            this.lblStartTab.TabIndex = 0;
+            this.lblStartTab.Text = "Startup tab";
+            //
+            // cmbStartTab
+            //
+            this.cmbStartTab.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.cmbStartTab.FormattingEnabled = true;
+            this.cmbStartTab.Items.AddRange(new object[] {
+            "Function",
+            "Totalizer",
+            "Fields"});
+            this.cmbStartTab.Location = new System.Drawing.Point(120, 15);
+            this.cmbStartTab.Name = "cmbStartTab";
+            this.cmbStartTab.Size = new System.Drawing.Size(121, 21);
+            this.cmbStartTab.TabIndex = 1;
+            //
+            // lblStartupLocation
+            //
+            this.lblStartupLocation.AutoSize = true;
+            this.lblStartupLocation.Location = new System.Drawing.Point(15, 48);
+            this.lblStartupLocation.Name = "lblStartupLocation";
+            this.lblStartupLocation.Size = new System.Drawing.Size(81, 13);
+            this.lblStartupLocation.TabIndex = 2;
+            this.lblStartupLocation.Text = "Startup location";
+            //
+            // cmbStartupLocation
+            //
+            this.cmbStartupLocation.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.cmbStartupLocation.FormattingEnabled = true;
+            this.cmbStartupLocation.Items.AddRange(new object[] {
+            "Last location",
+            "Primary display",
+            "Active display",
+            "Cursor location"});
+            this.cmbStartupLocation.Location = new System.Drawing.Point(120, 45);
+            this.cmbStartupLocation.Name = "cmbStartupLocation";
+            this.cmbStartupLocation.Size = new System.Drawing.Size(121, 21);
+            this.cmbStartupLocation.TabIndex = 3;
+            //
+            // chkAlwaysOnTop
+            //
+            this.chkAlwaysOnTop.AutoSize = true;
+            this.chkAlwaysOnTop.Location = new System.Drawing.Point(18, 80);
+            this.chkAlwaysOnTop.Name = "chkAlwaysOnTop";
+            this.chkAlwaysOnTop.Size = new System.Drawing.Size(92, 17);
+            this.chkAlwaysOnTop.TabIndex = 4;
+            this.chkAlwaysOnTop.Text = "Always on top";
+            this.chkAlwaysOnTop.UseVisualStyleBackColor = true;
+            //
+            // chkShowInTray
+            //
+            this.chkShowInTray.AutoSize = true;
+            this.chkShowInTray.Location = new System.Drawing.Point(18, 105);
+            this.chkShowInTray.Name = "chkShowInTray";
+            this.chkShowInTray.Size = new System.Drawing.Size(119, 17);
+            this.chkShowInTray.TabIndex = 5;
+            this.chkShowInTray.Text = "Show in system tray";
+            this.toolTip1.SetToolTip(this.chkShowInTray, "Will not show in task bar");
+            this.chkShowInTray.UseVisualStyleBackColor = true;
+            //
+            // chkMultiInstance
+            //
+            this.chkMultiInstance.AutoSize = true;
+            this.chkMultiInstance.Location = new System.Drawing.Point(18, 130);
+            this.chkMultiInstance.Name = "chkMultiInstance";
+            this.chkMultiInstance.Size = new System.Drawing.Size(137, 17);
+            this.chkMultiInstance.TabIndex = 6;
+            this.chkMultiInstance.Text = "Allow multiple instances";
+            this.chkMultiInstance.UseVisualStyleBackColor = true;
+            //
+            // chkUnarchiveTarget
+            //
+            this.chkUnarchiveTarget.AutoSize = true;
+            this.chkUnarchiveTarget.Location = new System.Drawing.Point(18, 155);
+            this.chkUnarchiveTarget.Name = "chkUnarchiveTarget";
+            this.chkUnarchiveTarget.Size = new System.Drawing.Size(183, 17);
+            this.chkUnarchiveTarget.TabIndex = 7;
+            this.chkUnarchiveTarget.Text = "Show unarchive target on startup";
+            this.chkUnarchiveTarget.UseVisualStyleBackColor = true;
+            //
             // EnvironmentSettings
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.Controls.Add(this.chkUnarchiveTarget);
+            this.Controls.Add(this.chkMultiInstance);
+            this.Controls.Add(this.chkShowInTray);
+            this.Controls.Add(this.chkAlwaysOnTop);
+            this.Controls.Add(this.cmbStartupLocation);
+            this.Controls.Add(this.lblStartupLocation);
+            this.Controls.Add(this.cmbStartTab);
+            this.Controls.Add(this.lblStartTab);
             this.Name = "EnvironmentSettings";
             this.Size = new System.Drawing.Size(334, 259);
             this.ResumeLayout(false);
+            this.PerformLayout();
 
         }
 
         #endregion
+
+        private System.Windows.Forms.Label lblStartTab;
+        private System.Windows.Forms.ComboBox cmbStartTab;
+        private System.Windows.Forms.Label lblStartupLocation;
+        private System.Windows.Forms.ComboBox cmbStartupLocation;
+        private System.Windows.Forms.CheckBox chkAlwaysOnTop;
+        private System.Windows.Forms.CheckBox chkShowInTray;
+        private System.Windows.Forms.CheckBox chkMultiInstance;
+        private System.Windows.Forms.CheckBox chkUnarchiveTarget;
+        private System.Windows.Forms.ToolTip toolTip1;
     }
 }

--- a/Settings/EnvironmentSettings.cs
+++ b/Settings/EnvironmentSettings.cs
@@ -1,20 +1,86 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Data;
-using System.Drawing;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using System;
 using System.Windows.Forms;
+using SMS_Search;
 
 namespace SMS_Search.Settings
 {
     public partial class EnvironmentSettings : UserControl
     {
+        private ConfigManager _config;
+        private bool _isLoaded = false;
+
+        public EnvironmentSettings(ConfigManager config)
+        {
+            InitializeComponent();
+            _config = config;
+            LoadSettings();
+            WireUpEvents();
+        }
+
         public EnvironmentSettings()
         {
             InitializeComponent();
+        }
+
+        public void Reload()
+        {
+            LoadSettings();
+        }
+
+        private void LoadSettings()
+        {
+            if (_config == null) return;
+            _isLoaded = false;
+
+            chkAlwaysOnTop.Checked = _config.GetValue("GENERAL", "ALWAYSONTOP") == "1";
+            chkShowInTray.Checked = _config.GetValue("GENERAL", "SHOWINTRAY") == "1";
+            chkMultiInstance.Checked = _config.GetValue("GENERAL", "MULTI_INSTANCE") == "1";
+            chkUnarchiveTarget.Checked = _config.GetValue("UNARCHIVE", "SHOWTARGET") == "1";
+
+            string startTab = _config.GetValue("GENERAL", "START_TAB");
+            if (startTab == "TLZ_TAB") cmbStartTab.Text = "Totalizer";
+            else if (startTab == "FIELDS") cmbStartTab.Text = "Fields";
+            else cmbStartTab.Text = "Function";
+
+            string startupLoc = _config.GetValue("GENERAL", "STARTUP_LOCATION");
+            if (startupLoc == "PRIMARY") cmbStartupLocation.Text = "Primary display";
+            else if (startupLoc == "ACTIVE") cmbStartupLocation.Text = "Active display";
+            else if (startupLoc == "CURSOR") cmbStartupLocation.Text = "Cursor location";
+            else cmbStartupLocation.Text = "Last location"; // Default
+
+            _isLoaded = true;
+        }
+
+        private void WireUpEvents()
+        {
+            chkAlwaysOnTop.CheckedChanged += (s, e) => SaveSetting("GENERAL", "ALWAYSONTOP", chkAlwaysOnTop.Checked ? "1" : "0");
+            chkShowInTray.CheckedChanged += (s, e) => SaveSetting("GENERAL", "SHOWINTRAY", chkShowInTray.Checked ? "1" : "0");
+            chkMultiInstance.CheckedChanged += (s, e) => SaveSetting("GENERAL", "MULTI_INSTANCE", chkMultiInstance.Checked ? "1" : "0");
+            chkUnarchiveTarget.CheckedChanged += (s, e) => SaveSetting("UNARCHIVE", "SHOWTARGET", chkUnarchiveTarget.Checked ? "1" : "0");
+
+            cmbStartTab.SelectedIndexChanged += (s, e) =>
+            {
+                string val = "FCT_TAB";
+                if (cmbStartTab.Text == "Totalizer") val = "TLZ_TAB";
+                else if (cmbStartTab.Text == "Fields") val = "FIELDS";
+                SaveSetting("GENERAL", "START_TAB", val);
+            };
+
+            cmbStartupLocation.SelectedIndexChanged += (s, e) =>
+            {
+                string val = "LAST";
+                if (cmbStartupLocation.Text == "Primary display") val = "PRIMARY";
+                else if (cmbStartupLocation.Text == "Active display") val = "ACTIVE";
+                else if (cmbStartupLocation.Text == "Cursor location") val = "CURSOR";
+                SaveSetting("GENERAL", "STARTUP_LOCATION", val);
+            };
+        }
+
+        private void SaveSetting(string section, string key, string value)
+        {
+            if (!_isLoaded || _config == null) return;
+            _config.SetValue(section, key, value);
+            _config.Save();
         }
     }
 }

--- a/Settings/GeneralSettings.Designer.cs
+++ b/Settings/GeneralSettings.Designer.cs
@@ -30,20 +30,12 @@ namespace SMS_Search.Settings
         {
             this.components = new System.ComponentModel.Container();
             this.label6 = new System.Windows.Forms.Label();
-            this.chkAlwaysOnTop = new System.Windows.Forms.CheckBox();
             this.chkDescriptionColumns = new System.Windows.Forms.CheckBox();
             this.chkResizeColumns = new System.Windows.Forms.CheckBox();
-            this.chkShowInTray = new System.Windows.Forms.CheckBox();
             this.chkCopyCleanSql = new System.Windows.Forms.CheckBox();
             this.chkSearchAny = new System.Windows.Forms.CheckBox();
-            this.chkMultiInstance = new System.Windows.Forms.CheckBox();
-            this.label7 = new System.Windows.Forms.Label();
-            this.cmbStartTab = new System.Windows.Forms.ComboBox();
-            this.chkUnarchiveTarget = new System.Windows.Forms.CheckBox();
             this.lblTableLookup = new System.Windows.Forms.Label();
             this.cmbTableLookup = new System.Windows.Forms.ComboBox();
-            this.label8 = new System.Windows.Forms.Label();
-            this.cmbStartupLocation = new System.Windows.Forms.ComboBox();
             this.lblAutoResizeLimit = new System.Windows.Forms.Label();
             this.txtAutoResizeLimit = new System.Windows.Forms.TextBox();
             this.chkHighlightMatches = new System.Windows.Forms.CheckBox();
@@ -52,9 +44,7 @@ namespace SMS_Search.Settings
             this.btnHighlightColor = new System.Windows.Forms.Button();
             this.toolTip1 = new System.Windows.Forms.ToolTip(this.components);
             this.colorDialog1 = new System.Windows.Forms.ColorDialog();
-            this.grpEnvironment = new System.Windows.Forms.GroupBox();
             ((System.ComponentModel.ISupportInitialize)(this.picHighlightWarning)).BeginInit();
-            this.grpEnvironment.SuspendLayout();
             this.SuspendLayout();
             // 
             // label6
@@ -65,17 +55,6 @@ namespace SMS_Search.Settings
             this.label6.Size = new System.Drawing.Size(126, 13);
             this.label6.TabIndex = 0;
             this.label6.Text = "Set SMS Search defaults";
-            // 
-            // chkAlwaysOnTop
-            // 
-            this.chkAlwaysOnTop.AutoSize = true;
-            this.chkAlwaysOnTop.CheckAlign = System.Drawing.ContentAlignment.MiddleRight;
-            this.chkAlwaysOnTop.Location = new System.Drawing.Point(-10, 59);
-            this.chkAlwaysOnTop.Name = "chkAlwaysOnTop";
-            this.chkAlwaysOnTop.Size = new System.Drawing.Size(92, 17);
-            this.chkAlwaysOnTop.TabIndex = 1;
-            this.chkAlwaysOnTop.Text = "Always on top";
-            this.chkAlwaysOnTop.UseVisualStyleBackColor = true;
             // 
             // chkDescriptionColumns
             // 
@@ -99,19 +78,6 @@ namespace SMS_Search.Settings
             this.chkResizeColumns.Text = "Resize columns on description toggle";
             this.chkResizeColumns.UseVisualStyleBackColor = true;
             // 
-            // chkShowInTray
-            // 
-            this.chkShowInTray.AutoSize = true;
-            this.chkShowInTray.CheckAlign = System.Drawing.ContentAlignment.MiddleRight;
-            this.chkShowInTray.Location = new System.Drawing.Point(103, 59);
-            this.chkShowInTray.Name = "chkShowInTray";
-            this.chkShowInTray.Size = new System.Drawing.Size(119, 17);
-            this.chkShowInTray.TabIndex = 4;
-            this.chkShowInTray.Text = "Show in system tray";
-            this.chkShowInTray.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
-            this.toolTip1.SetToolTip(this.chkShowInTray, "Will not show in task bar");
-            this.chkShowInTray.UseVisualStyleBackColor = true;
-            // 
             // chkCopyCleanSql
             // 
             this.chkCopyCleanSql.AutoSize = true;
@@ -134,50 +100,6 @@ namespace SMS_Search.Settings
             this.chkSearchAny.Text = "Search anywhere in description";
             this.chkSearchAny.UseVisualStyleBackColor = true;
             // 
-            // chkMultiInstance
-            // 
-            this.chkMultiInstance.AutoSize = true;
-            this.chkMultiInstance.CheckAlign = System.Drawing.ContentAlignment.MiddleRight;
-            this.chkMultiInstance.Location = new System.Drawing.Point(228, 59);
-            this.chkMultiInstance.Name = "chkMultiInstance";
-            this.chkMultiInstance.Size = new System.Drawing.Size(137, 17);
-            this.chkMultiInstance.TabIndex = 7;
-            this.chkMultiInstance.Text = "Allow multiple instances";
-            this.chkMultiInstance.UseVisualStyleBackColor = true;
-            // 
-            // label7
-            // 
-            this.label7.AutoSize = true;
-            this.label7.Location = new System.Drawing.Point(214, 28);
-            this.label7.Name = "label7";
-            this.label7.Size = new System.Drawing.Size(59, 13);
-            this.label7.TabIndex = 8;
-            this.label7.Text = "Startup tab";
-            // 
-            // cmbStartTab
-            // 
-            this.cmbStartTab.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.cmbStartTab.FormattingEnabled = true;
-            this.cmbStartTab.Items.AddRange(new object[] {
-            "Function",
-            "Totalizer",
-            "Fields"});
-            this.cmbStartTab.Location = new System.Drawing.Point(289, 25);
-            this.cmbStartTab.Name = "cmbStartTab";
-            this.cmbStartTab.Size = new System.Drawing.Size(85, 21);
-            this.cmbStartTab.TabIndex = 9;
-            // 
-            // chkUnarchiveTarget
-            // 
-            this.chkUnarchiveTarget.AutoSize = true;
-            this.chkUnarchiveTarget.CheckAlign = System.Drawing.ContentAlignment.MiddleRight;
-            this.chkUnarchiveTarget.Location = new System.Drawing.Point(-9, 93);
-            this.chkUnarchiveTarget.Name = "chkUnarchiveTarget";
-            this.chkUnarchiveTarget.Size = new System.Drawing.Size(183, 17);
-            this.chkUnarchiveTarget.TabIndex = 10;
-            this.chkUnarchiveTarget.Text = "Show unarchive target on startup";
-            this.chkUnarchiveTarget.UseVisualStyleBackColor = true;
-            // 
             // lblTableLookup
             // 
             this.lblTableLookup.AutoSize = true;
@@ -198,29 +120,6 @@ namespace SMS_Search.Settings
             this.cmbTableLookup.Name = "cmbTableLookup";
             this.cmbTableLookup.Size = new System.Drawing.Size(102, 21);
             this.cmbTableLookup.TabIndex = 12;
-            // 
-            // label8
-            // 
-            this.label8.AutoSize = true;
-            this.label8.Location = new System.Drawing.Point(192, 94);
-            this.label8.Name = "label8";
-            this.label8.Size = new System.Drawing.Size(81, 13);
-            this.label8.TabIndex = 13;
-            this.label8.Text = "Startup location";
-            // 
-            // cmbStartupLocation
-            // 
-            this.cmbStartupLocation.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.cmbStartupLocation.FormattingEnabled = true;
-            this.cmbStartupLocation.Items.AddRange(new object[] {
-            "Last location",
-            "Primary display",
-            "Active display",
-            "Cursor location"});
-            this.cmbStartupLocation.Location = new System.Drawing.Point(279, 91);
-            this.cmbStartupLocation.Name = "cmbStartupLocation";
-            this.cmbStartupLocation.Size = new System.Drawing.Size(100, 21);
-            this.cmbStartupLocation.TabIndex = 14;
             // 
             // lblAutoResizeLimit
             // 
@@ -276,28 +175,10 @@ namespace SMS_Search.Settings
             this.btnHighlightColor.TabIndex = 20;
             this.btnHighlightColor.UseVisualStyleBackColor = true;
             // 
-            // grpEnvironment
-            // 
-            this.grpEnvironment.Controls.Add(this.label7);
-            this.grpEnvironment.Controls.Add(this.chkAlwaysOnTop);
-            this.grpEnvironment.Controls.Add(this.chkShowInTray);
-            this.grpEnvironment.Controls.Add(this.chkMultiInstance);
-            this.grpEnvironment.Controls.Add(this.cmbStartTab);
-            this.grpEnvironment.Controls.Add(this.chkUnarchiveTarget);
-            this.grpEnvironment.Controls.Add(this.label8);
-            this.grpEnvironment.Controls.Add(this.cmbStartupLocation);
-            this.grpEnvironment.Location = new System.Drawing.Point(18, 414);
-            this.grpEnvironment.Name = "grpEnvironment";
-            this.grpEnvironment.Size = new System.Drawing.Size(389, 143);
-            this.grpEnvironment.TabIndex = 21;
-            this.grpEnvironment.TabStop = false;
-            this.grpEnvironment.Text = "Environment";
-            // 
             // GeneralSettings
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.Controls.Add(this.grpEnvironment);
             this.Controls.Add(this.btnHighlightColor);
             this.Controls.Add(this.lblHighlightColor);
             this.Controls.Add(this.picHighlightWarning);
@@ -314,8 +195,6 @@ namespace SMS_Search.Settings
             this.Name = "GeneralSettings";
             this.Size = new System.Drawing.Size(430, 696);
             ((System.ComponentModel.ISupportInitialize)(this.picHighlightWarning)).EndInit();
-            this.grpEnvironment.ResumeLayout(false);
-            this.grpEnvironment.PerformLayout();
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -324,20 +203,12 @@ namespace SMS_Search.Settings
         #endregion
 
         private System.Windows.Forms.Label label6;
-        private System.Windows.Forms.CheckBox chkAlwaysOnTop;
         private System.Windows.Forms.CheckBox chkDescriptionColumns;
         private System.Windows.Forms.CheckBox chkResizeColumns;
-        private System.Windows.Forms.CheckBox chkShowInTray;
         private System.Windows.Forms.CheckBox chkCopyCleanSql;
         private System.Windows.Forms.CheckBox chkSearchAny;
-        private System.Windows.Forms.CheckBox chkMultiInstance;
-        private System.Windows.Forms.Label label7;
-        private System.Windows.Forms.ComboBox cmbStartTab;
-        private System.Windows.Forms.CheckBox chkUnarchiveTarget;
         private System.Windows.Forms.Label lblTableLookup;
         private System.Windows.Forms.ComboBox cmbTableLookup;
-        private System.Windows.Forms.Label label8;
-        private System.Windows.Forms.ComboBox cmbStartupLocation;
         private System.Windows.Forms.Label lblAutoResizeLimit;
         private System.Windows.Forms.TextBox txtAutoResizeLimit;
         private System.Windows.Forms.CheckBox chkHighlightMatches;
@@ -346,6 +217,5 @@ namespace SMS_Search.Settings
         private System.Windows.Forms.Button btnHighlightColor;
         private System.Windows.Forms.ToolTip toolTip1;
         private System.Windows.Forms.ColorDialog colorDialog1;
-        private System.Windows.Forms.GroupBox grpEnvironment;
     }
 }

--- a/Settings/GeneralSettings.cs
+++ b/Settings/GeneralSettings.cs
@@ -40,29 +40,14 @@ namespace SMS_Search.Settings
             if (_config == null) return;
             _isLoaded = false;
 
-            chkAlwaysOnTop.Checked = _config.GetValue("GENERAL", "ALWAYSONTOP") == "1";
             chkDescriptionColumns.Checked = _config.GetValue("GENERAL", "DESCRIPTIONCOLUMNS") == "1";
             chkResizeColumns.Checked = _config.GetValue("GENERAL", "RESIZECOLUMNS") == "1";
-            chkShowInTray.Checked = _config.GetValue("GENERAL", "SHOWINTRAY") == "1";
             chkCopyCleanSql.Checked = _config.GetValue("GENERAL", "COPYCLEANSQL") == "1";
             chkSearchAny.Checked = _config.GetValue("GENERAL", "SEARCHANY") == "1";
-            chkMultiInstance.Checked = _config.GetValue("GENERAL", "MULTI_INSTANCE") == "1";
-            chkUnarchiveTarget.Checked = _config.GetValue("UNARCHIVE", "SHOWTARGET") == "1";
-
-            string startTab = _config.GetValue("GENERAL", "START_TAB");
-            if (startTab == "TLZ_TAB") cmbStartTab.Text = "Totalizer";
-            else if (startTab == "FIELDS") cmbStartTab.Text = "Fields";
-            else cmbStartTab.Text = "Function";
 
             string tableLookup = _config.GetValue("GENERAL", "TABLE_LOOKUP");
             if (tableLookup == "RECORDS") cmbTableLookup.Text = "Show Records";
             else cmbTableLookup.Text = "Show Fields";
-
-            string startupLoc = _config.GetValue("GENERAL", "STARTUP_LOCATION");
-            if (startupLoc == "PRIMARY") cmbStartupLocation.Text = "Primary display";
-            else if (startupLoc == "ACTIVE") cmbStartupLocation.Text = "Active display";
-            else if (startupLoc == "CURSOR") cmbStartupLocation.Text = "Cursor location";
-            else cmbStartupLocation.Text = "Last location"; // Default
 
             string autoResizeLimit = _config.GetValue("GENERAL", "AUTO_RESIZE_LIMIT");
             if (string.IsNullOrEmpty(autoResizeLimit)) autoResizeLimit = "5000";
@@ -84,37 +69,16 @@ namespace SMS_Search.Settings
 
         private void WireUpEvents()
         {
-            chkAlwaysOnTop.CheckedChanged += (s, e) => SaveSetting("GENERAL", "ALWAYSONTOP", chkAlwaysOnTop.Checked ? "1" : "0");
             chkDescriptionColumns.CheckedChanged += (s, e) => SaveSetting("GENERAL", "DESCRIPTIONCOLUMNS", chkDescriptionColumns.Checked ? "1" : "0");
             chkResizeColumns.CheckedChanged += (s, e) => SaveSetting("GENERAL", "RESIZECOLUMNS", chkResizeColumns.Checked ? "1" : "0");
-            chkShowInTray.CheckedChanged += (s, e) => SaveSetting("GENERAL", "SHOWINTRAY", chkShowInTray.Checked ? "1" : "0");
             chkCopyCleanSql.CheckedChanged += (s, e) => SaveSetting("GENERAL", "COPYCLEANSQL", chkCopyCleanSql.Checked ? "1" : "0");
             chkSearchAny.CheckedChanged += (s, e) => SaveSetting("GENERAL", "SEARCHANY", chkSearchAny.Checked ? "1" : "0");
-            chkMultiInstance.CheckedChanged += (s, e) => SaveSetting("GENERAL", "MULTI_INSTANCE", chkMultiInstance.Checked ? "1" : "0");
-            chkUnarchiveTarget.CheckedChanged += (s, e) => SaveSetting("UNARCHIVE", "SHOWTARGET", chkUnarchiveTarget.Checked ? "1" : "0");
-
-            cmbStartTab.SelectedIndexChanged += (s, e) =>
-            {
-                string val = "FCT_TAB";
-                if (cmbStartTab.Text == "Totalizer") val = "TLZ_TAB";
-                else if (cmbStartTab.Text == "Fields") val = "FIELDS";
-                SaveSetting("GENERAL", "START_TAB", val);
-            };
 
             cmbTableLookup.SelectedIndexChanged += (s, e) =>
             {
                 string val = "FIELDS";
                 if (cmbTableLookup.Text == "Show Records") val = "RECORDS";
                 SaveSetting("GENERAL", "TABLE_LOOKUP", val);
-            };
-
-            cmbStartupLocation.SelectedIndexChanged += (s, e) =>
-            {
-                string val = "LAST";
-                if (cmbStartupLocation.Text == "Primary display") val = "PRIMARY";
-                else if (cmbStartupLocation.Text == "Active display") val = "ACTIVE";
-                else if (cmbStartupLocation.Text == "Cursor location") val = "CURSOR";
-                SaveSetting("GENERAL", "STARTUP_LOCATION", val);
             };
 
             txtAutoResizeLimit.Leave += (s, e) =>


### PR DESCRIPTION
Moved the Environment-related controls from the `GeneralSettings` UserControl to the `EnvironmentSettings` UserControl. This includes moving the UI controls (CheckBoxes, ComboBoxes, Labels) and the associated logic for loading and saving these settings via `ConfigManager`. Also added the missing constructor to `EnvironmentSettings` to accept `ConfigManager`, resolving a compilation error in `frmConfig.cs`. The `GeneralSettings` panel was cleaned up to remove the moved controls and their event handlers.

---
*PR created automatically by Jules for task [1197805569087041844](https://jules.google.com/task/1197805569087041844) started by @Rapscallion0*