### PR TITLE
Fix compilation errors in Designer files

### DIFF
--- a/Settings/ApplicationSettings.Designer.cs
+++ b/Settings/ApplicationSettings.Designer.cs
@@ -40,7 +40,6 @@ namespace SMS_Search.Settings
             this.chkUnarchiveTarget = new System.Windows.Forms.CheckBox();
             this.chkCheckUpdate = new System.Windows.Forms.CheckBox();
             this.btnChkUpdate = new System.Windows.Forms.Button();
-            this.chkCopyCleanSql = new System.Windows.Forms.CheckBox();
             this.toolTip1 = new System.Windows.Forms.ToolTip(this.components);
             this.SuspendLayout();
             // 

--- a/Settings/frmConfig.Designer.cs
+++ b/Settings/frmConfig.Designer.cs
@@ -39,7 +39,6 @@ namespace SMS_Search.Settings
             this.btnRevert = new System.Windows.Forms.Button();
             this.btnClose = new System.Windows.Forms.Button();
             this.toolTip1 = new System.Windows.Forms.ToolTip(this.components);
-            this.lblConfigFilePath = new System.Windows.Forms.Label();
             ((System.ComponentModel.ISupportInitialize)(this.splitConfig)).BeginInit();
             this.splitConfig.Panel1.SuspendLayout();
             this.splitConfig.SuspendLayout();


### PR DESCRIPTION
This PR addresses build errors caused by orphaned control initializations in Designer files.

**Changes:**
- Removed `chkCopyCleanSql` initialization from `ApplicationSettings.Designer.cs`.
- Removed `lblConfigFilePath` initialization from `frmConfig.Designer.cs`.

These controls appear to have been removed or moved (e.g., `chkCopyCleanSql` to `CleanSqlSettings`) but their initialization code remained, causing CS1061 errors. Fixing these errors should also resolve the associated CS0649 "never assigned to" warnings that were likely side effects of the broken build state.

---
*PR created automatically by Jules for task [17284302196151795952](https://jules.google.com/task/17284302196151795952) started by @Rapscallion0*