### PR TITLE
Fix NullReferenceException and unassigned field warnings in Settings forms

### DIFF
--- a/Settings/LoggingSettings.Designer.cs
+++ b/Settings/LoggingSettings.Designer.cs
@@ -36,6 +36,10 @@ namespace SMS_Search.Settings
             this.lblRetention = new System.Windows.Forms.Label();
             this.numRetention = new System.Windows.Forms.NumericUpDown();
             this.toolTip1 = new System.Windows.Forms.ToolTip(this.components);
+            this.lblLogFile = new System.Windows.Forms.Label();
+            this.txtLogFile = new System.Windows.Forms.TextBox();
+            this.btnOpenLog = new System.Windows.Forms.Button();
+            this.btnOpenLogFolder = new System.Windows.Forms.Button();
             ((System.ComponentModel.ISupportInitialize)(this.numRetention)).BeginInit();
             this.SuspendLayout();
             //

--- a/Settings/frmConfig.Designer.cs
+++ b/Settings/frmConfig.Designer.cs
@@ -39,6 +39,9 @@ namespace SMS_Search.Settings
             this.btnRevert = new System.Windows.Forms.Button();
             this.btnClose = new System.Windows.Forms.Button();
             this.toolTip1 = new System.Windows.Forms.ToolTip(this.components);
+            this.btnOpenConfig = new System.Windows.Forms.Button();
+            this.lblAutoSave = new System.Windows.Forms.Label();
+            this.lblSavedStatus = new System.Windows.Forms.Label();
             ((System.ComponentModel.ISupportInitialize)(this.splitConfig)).BeginInit();
             this.splitConfig.Panel1.SuspendLayout();
             this.splitConfig.SuspendLayout();


### PR DESCRIPTION
This PR addresses runtime `NullReferenceException` crashes and compiler warnings ("Field is never assigned to") in the Settings dialogs.

Changes:
- In `Settings/frmConfig.Designer.cs`: Added `new` statements for `btnOpenConfig`, `lblAutoSave`, and `lblSavedStatus` in `InitializeComponent`.
- In `Settings/LoggingSettings.Designer.cs`: Added `new` statements for `lblLogFile`, `txtLogFile`, `btnOpenLog`, and `btnOpenLogFolder` in `InitializeComponent`.

These controls were previously declared but never instantiated before being accessed, causing the application to crash when opening the Settings window.

---
*PR created automatically by Jules for task [39335652482878991](https://jules.google.com/task/39335652482878991) started by @Rapscallion0*