### PR TITLE
Fix Settings Window Centering and TreeView Icons

### DIFF
--- a/Settings/frmConfig.cs
+++ b/Settings/frmConfig.cs
@@ -28,9 +28,6 @@ namespace SMS_Search.Settings
         public frmConfig()
         {
             InitializeComponent();
-            base.StartPosition = FormStartPosition.Manual;
-            base.Top = (Screen.PrimaryScreen.WorkingArea.Height - base.Height) / 2;
-            base.Left = (Screen.PrimaryScreen.WorkingArea.Width - base.Width) / 2;
 
             toolTip1.SetToolTip(btnOpenConfig, Path.Combine(Application.StartupPath, "SMSSearch_settings.json"));
 
@@ -86,6 +83,7 @@ namespace SMS_Search.Settings
             log.Logger(LogLevel.Info, "Settings window opened");
 
             // Icons
+            tvSettings.ImageList = null;
             imgListIcons.Images.Clear();
             imgListIcons.Images.Add("General", IconLoader.GetIcon("General"));
             imgListIcons.Images.Add("Application", IconLoader.GetIcon("Application"));
@@ -96,6 +94,7 @@ namespace SMS_Search.Settings
             imgListIcons.Images.Add("CleanSql", IconLoader.GetIcon("CleanSql"));
             imgListIcons.Images.Add("Launcher", IconLoader.GetIcon("Launcher"));
             imgListIcons.Images.Add("Logging", IconLoader.GetIcon("Logging"));
+            tvSettings.ImageList = imgListIcons;
 
             // Expand all nodes
             tvSettings.ExpandAll();

--- a/frmMain.cs
+++ b/frmMain.cs
@@ -199,7 +199,7 @@ namespace SMS_Search
                 using (frmConfig frmConfig = new frmConfig())
                 {
                     frmConfig.ForceDatabaseSetup = true;
-                    if (frmConfig.ShowDialog() != DialogResult.OK)
+                    if (frmConfig.ShowDialog(this) != DialogResult.OK)
                     {
                         Application.Exit();
                         return;
@@ -409,7 +409,7 @@ namespace SMS_Search
 			{
 				using (var cfg = new frmConfig())
 				{
-					cfg.ShowDialog();
+					cfg.ShowDialog(this);
 				}
                 config.Load(); // Re-load config in case it was changed
                 log.ReloadConfig();
@@ -1238,7 +1238,7 @@ namespace SMS_Search
 			{
 				frmConfig frmConfig = new frmConfig();
 				frmConfig.StartPosition = FormStartPosition.CenterParent;
-				frmConfig.ShowDialog();
+				frmConfig.ShowDialog(this);
 
                 bool useWinAuth = config.GetValue("CONNECTION", "WINDOWSAUTH") == "1" || string.IsNullOrEmpty(config.GetValue("CONNECTION", "WINDOWSAUTH"));
                 string user = useWinAuth ? null : config.GetValue("CONNECTION", "SQLUSER");


### PR DESCRIPTION
This change fixes two UI issues in the Settings dialog:
1.  **Centering:** The Settings window now correctly centers on the Main Application window instead of the screen. This was achieved by removing manual positioning logic in the `frmConfig` constructor and ensuring `frmMain` passes itself as the owner when calling `ShowDialog`.
2.  **Icons:** Fixed a bug where selecting a TreeView node caused its icon to revert to the default (General) icon. This was resolved by detaching the `ImageList` before populating it and reattaching it afterwards, forcing the TreeView to correctly resolve `SelectedImageKey` mappings.

---
*PR created automatically by Jules for task [520526743964499638](https://jules.google.com/task/520526743964499638) started by @Rapscallion0*