### PR TITLE
Suppress Enter key notification sound in search fields

### DIFF
--- a/frmMain.cs
+++ b/frmMain.cs
@@ -1031,6 +1031,10 @@ namespace SMS_Search
 			if (e.KeyCode == Keys.F5 || (e.KeyCode == Keys.Return && (txtNumFct.Focused || txtDescFct.Focused || txtNumTlz.Focused || txtDescTlz.Focused || txtNumFld.Focused || txtDescFld.Focused || cmbTableFld.Focused)))
 			{
 				btnPopGrid.PerformClick();
+				if (e.KeyCode == Keys.Return)
+				{
+					e.SuppressKeyPress = true;
+				}
 			}
 		}
         #endregion


### PR DESCRIPTION
Suppress Enter key notification sound in search fields

Prevent the default system "ding" sound when searching via the Enter key in the main search form description and related fields. This is achieved by setting `SuppressKeyPress = true` in the `KeyDown` event handler after triggering the search action.

---
*PR created automatically by Jules for task [804732084495675955](https://jules.google.com/task/804732084495675955) started by @Rapscallion0*