### PR TITLE
Fix: Ensure data is loaded before resizing columns in Virtual Mode

### DIFF
--- a/frmMain.cs
+++ b/frmMain.cs
@@ -653,7 +653,7 @@ namespace SMS_Search
 			}
 			setTabTextFocus();
 			await setColumnArrayAsync();
-			setHeaders();
+			await setHeadersAsync();
 			SetBusy(false);
 		}
 
@@ -1297,7 +1297,7 @@ namespace SMS_Search
             }
 		}
 
-		private void setHeaders()
+		private async Task setHeadersAsync()
 		{
             bool showDesc = chkToggleDesc.Checked;
 
@@ -1335,7 +1335,7 @@ namespace SMS_Search
                 }
                 else
                 {
-                    ResizeColumnsBasedOnFirstRows(100);
+                    await ResizeColumnsBasedOnFirstRowsAsync(100);
                 }
 
 			    if (firstDisplayedScrollingColumnIndex >= 0)
@@ -1345,9 +1345,15 @@ namespace SMS_Search
 			}
 		}
 
-        private void ResizeColumnsBasedOnFirstRows(int rowLimit)
+        private async Task ResizeColumnsBasedOnFirstRowsAsync(int rowLimit)
         {
             if (dGrd.RowCount == 0) return;
+
+            // In Virtual Mode, we must ensure data is loaded before measuring
+            if (dGrd.VirtualMode)
+            {
+                await _gridContext.WaitForRowAsync(0);
+            }
 
             int rowsToCheck = Math.Min(dGrd.RowCount, rowLimit);
 
@@ -1370,9 +1376,9 @@ namespace SMS_Search
             }
         }
 
-		private void chkToggleDesc_CheckedChanged(object sender, EventArgs e)
+		private async void chkToggleDesc_CheckedChanged(object sender, EventArgs e)
 		{
-			setHeaders();
+			await setHeadersAsync();
 			setTabTextFocus();
 		}
 


### PR DESCRIPTION
This PR fixes a bug where the `DataGridView` columns were resizing to minimal width when the result set exceeded the auto-resize limit (default 5000 rows).

In Virtual Mode, accessing cell values before the data has been fetched results in null/empty values. The previous synchronous `ResizeColumnsBasedOnFirstRows` method did not wait for the data to be loaded, leading to incorrect width calculations.

Changes:
1.  **Async Resizing:** `ResizeColumnsBasedOnFirstRows` is now `ResizeColumnsBasedOnFirstRowsAsync` and awaits `_gridContext.WaitForRowAsync(0)`. This ensures that the first batch of data (page size 100) is present in the cache before the loop attempts to measure the `PreferredSize` of cells.
2.  **Propagated Async:** The `setHeaders` method was promoted to `async Task setHeadersAsync` to accommodate the async resize call.
3.  **Updated Callers:** The `btnPopGrid_Click` and `chkToggleDesc_CheckedChanged` event handlers were updated to await `setHeadersAsync`.

This ensures columns are sized correctly based on the actual content of the first 100 rows even for large datasets running in Virtual Mode.

---
*PR created automatically by Jules for task [585835853441768213](https://jules.google.com/task/585835853441768213) started by @Rapscallion0*