### PR TITLE
Fix Virtual Mode Column Resize Issue

### DIFF
--- a/VirtualGridContext.cs
+++ b/VirtualGridContext.cs
@@ -129,6 +129,27 @@ namespace SMS_Search
             }
         }
 
+        public async Task EnsureRangeLoadedAsync(int startIndex, int count)
+        {
+            if (count <= 0) return;
+            var tasks = new List<Task>();
+            int endRow = startIndex + count;
+
+            // Trigger fetch for all pages in range first
+            for (int i = startIndex; i < endRow; i += PageSize)
+            {
+                GetValue(i, 0);
+            }
+
+            // Then wait for all of them
+            for (int i = startIndex; i < endRow; i += PageSize)
+            {
+                tasks.Add(WaitForRowAsync(i));
+            }
+
+            await Task.WhenAll(tasks);
+        }
+
         public async Task ApplySortAsync(string column)
         {
             if (SortColumn == column)

--- a/frmMain.cs
+++ b/frmMain.cs
@@ -1335,6 +1335,10 @@ namespace SMS_Search
 
                 if (dGrd.RowCount <= limit)
                 {
+                    if (dGrd.VirtualMode)
+                    {
+                        await _gridContext.EnsureRangeLoadedAsync(0, dGrd.RowCount);
+                    }
 				    dGrd.AutoResizeColumns(DataGridViewAutoSizeColumnsMode.AllCells);
                 }
                 else


### PR DESCRIPTION
Fixes an issue where the grid columns would not resize correctly when executing a query with results smaller than the auto-resize threshold (default 5000). The issue was caused by `AutoResizeColumns` running before the Virtual Mode cache was populated. 

The fix ensures that all necessary data pages are fetched and cached before the resize operation is triggered.

---
*PR created automatically by Jules for task [16877332685301630715](https://jules.google.com/task/16877332685301630715) started by @Rapscallion0*