### PR TITLE
Move Export CSV to Context Menu

### DIFF
--- a/frmMain.Designer.cs
+++ b/frmMain.Designer.cs
@@ -107,7 +107,6 @@ namespace SMS_Search
         private Label lblFilter;
         private TextBox txtGridFilter;
         private Button btnClearFilter;
-        private Button btnExport;
         private Label lblMatchCount;
         private Button btnPrevMatch;
         private Button btnNextMatch;
@@ -203,7 +202,6 @@ namespace SMS_Search
             this.btnNextMatch = new System.Windows.Forms.Button();
             this.btnPrevMatch = new System.Windows.Forms.Button();
             this.lblMatchCount = new System.Windows.Forms.Label();
-            this.btnExport = new System.Windows.Forms.Button();
             this.btnClearFilter = new System.Windows.Forms.Button();
             this.txtGridFilter = new System.Windows.Forms.TextBox();
             this.lblFilter = new System.Windows.Forms.Label();
@@ -1071,7 +1069,6 @@ namespace SMS_Search
             this.splitContainer.Panel2.Controls.Add(this.btnNextMatch);
             this.splitContainer.Panel2.Controls.Add(this.btnPrevMatch);
             this.splitContainer.Panel2.Controls.Add(this.lblMatchCount);
-            this.splitContainer.Panel2.Controls.Add(this.btnExport);
             this.splitContainer.Panel2.Controls.Add(this.btnClearFilter);
             this.splitContainer.Panel2.Controls.Add(this.txtGridFilter);
             this.splitContainer.Panel2.Controls.Add(this.lblFilter);
@@ -1116,16 +1113,6 @@ namespace SMS_Search
             this.lblMatchCount.Size = new System.Drawing.Size(0, 15);
             this.lblMatchCount.TabIndex = 14;
             this.lblMatchCount.Visible = false;
-            // 
-            // btnExport
-            // 
-            this.btnExport.Location = new System.Drawing.Point(280, 34);
-            this.btnExport.Name = "btnExport";
-            this.btnExport.Size = new System.Drawing.Size(75, 25);
-            this.btnExport.TabIndex = 12;
-            this.btnExport.Text = "Export CSV";
-            this.btnExport.UseVisualStyleBackColor = true;
-            this.btnExport.Click += new System.EventHandler(this.btnExport_Click);
             // 
             // btnClearFilter
             // 

--- a/frmMain.cs
+++ b/frmMain.cs
@@ -1203,6 +1203,13 @@ namespace SMS_Search
             var itemClear = menu.Items.Add("Clear result");
             itemClear.Click += (s, e) => ClearResults();
 
+            // 7. Separator
+            menu.Items.Add(new ToolStripSeparator());
+
+            // 8. Export to CSV
+            var itemExport = menu.Items.Add("Export results to CSV");
+            itemExport.Click += (s, e) => ExportToCsv();
+
             dGrd.ContextMenuStrip = menu;
             _headerContextMenu = menu; // Reuse for header
         }
@@ -1982,7 +1989,7 @@ namespace SMS_Search
             }
         }
 
-        private async void btnExport_Click(object sender, EventArgs e)
+        private async void ExportToCsv()
         {
             if (dGrd.RowCount == 0) return;
 


### PR DESCRIPTION
Moved the CSV export functionality from a standalone button to the grid's context menu. This involved removing the button from the UI and code, refactoring the click handler into a reusable method, and adding the corresponding menu item with a separator.

---
*PR created automatically by Jules for task [16781761880835775638](https://jules.google.com/task/16781761880835775638) started by @Rapscallion0*