### PR TITLE
Fix silent startup failure and make release publishing optional

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -1,27 +1,52 @@
-// using Ini;
-using Log;
-using SingleInstance;
 using System;
+using System.Windows.Forms;
+using System.Runtime.CompilerServices;
 using System.IO;
 using System.Threading;
-using System.Windows.Forms;
+using Log;
+using SingleInstance;
+
 namespace SMS_Search
 {
 	internal class Program
 	{
 		public static string[] Params;
-        private static Logfile log;
 
 		[STAThread]
 		private static void Main(string[] args)
 		{
+            try
+            {
+                Program.Params = args;
+                AppBootstrapper.Run(args);
+            }
+            catch (Exception ex)
+            {
+                // This block catches exceptions when dependencies (e.g. Serilog.dll) are missing.
+                // Since Program.Main does not reference external types directly, it can execute
+                // and catch the TypeInitializationException or FileNotFoundException thrown when loading AppBootstrapper.
+                MessageBox.Show("A fatal startup error occurred.\n\n" +
+                                "It appears some dependencies are missing or the application is corrupted.\n" +
+                                "Details:\n" + ex.ToString(),
+                                "Startup Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+            }
+		}
+	}
+
+    internal static class AppBootstrapper
+    {
+        private static Logfile log;
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static void Run(string[] args)
+        {
+            // Initialization Logic moved here to isolate dependencies
             bool isListener = args.Length > 0 && args[0] == "--listener";
             log = new Logfile(isListener ? "Listener" : "App");
 
             Application.ThreadException += new ThreadExceptionEventHandler(Application_ThreadException);
             AppDomain.CurrentDomain.UnhandledException += new UnhandledExceptionEventHandler(CurrentDomain_UnhandledException);
 
-			Program.Params = args;
 			Application.EnableVisualStyles();
 			Application.SetCompatibleTextRenderingDefault(false);
 
@@ -39,28 +64,31 @@ namespace SMS_Search
                 ConfigManager config = new ConfigManager(Path.Combine(Application.StartupPath, "SMSSearch_settings.json"));
 			    if (config.GetValue("GENERAL", "MULTI_INSTANCE") == "1")
 			    {
-				    Application.Run(new frmMain(Program.Params));
+				    Application.Run(new frmMain(args));
 				    return;
 			    }
-			    SingleApplication.Run(new frmMain(Program.Params));
+			    SingleApplication.Run(new frmMain(args));
             }
             catch (Exception ex)
             {
-                log.Logger(LogLevel.Critical, "Fatal Error in Main: " + ex.ToString());
+                if (log != null)
+                    log.Logger(LogLevel.Critical, "Fatal Error in AppBootstrapper.Run: " + ex.ToString());
                 MessageBox.Show("A fatal error occurred. Check logs for details.\n" + ex.Message, "Fatal Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
-		}
+        }
 
         static void Application_ThreadException(object sender, ThreadExceptionEventArgs e)
         {
-            log.Logger(LogLevel.Critical, "Unhandled Thread Exception: " + e.Exception.ToString());
+            if (log != null)
+                log.Logger(LogLevel.Critical, "Unhandled Thread Exception: " + e.Exception.ToString());
             MessageBox.Show("An unexpected error occurred. \n" + e.Exception.Message, "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
         }
 
         static void CurrentDomain_UnhandledException(object sender, UnhandledExceptionEventArgs e)
         {
-            log.Logger(LogLevel.Critical, "Unhandled Domain Exception: " + (e.ExceptionObject as Exception).ToString());
+            if (log != null)
+                log.Logger(LogLevel.Critical, "Unhandled Domain Exception: " + (e.ExceptionObject as Exception).ToString());
             MessageBox.Show("A fatal error occurred. \n" + (e.ExceptionObject as Exception).Message, "Fatal Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
         }
-	}
+    }
 }

--- a/publish_release.ps1
+++ b/publish_release.ps1
@@ -5,6 +5,21 @@ param(
 
 $ErrorActionPreference = "Stop"
 
+# Prompt user for confirmation before proceeding with publish
+Add-Type -AssemblyName System.Windows.Forms
+$confirm = [System.Windows.Forms.MessageBox]::Show(
+    "Do you want to publish this release to GitHub?" + [Environment]::NewLine +
+    "This will bump version, push to git, and create a release.",
+    "Confirm Publish",
+    [System.Windows.Forms.MessageBoxButtons]::YesNo,
+    [System.Windows.Forms.MessageBoxIcon]::Question
+)
+
+if ($confirm -ne 'Yes') {
+    Write-Host "Publish cancelled by user."
+    exit 0
+}
+
 try {
     Write-Host "Starting GitHub Release process..."
 


### PR DESCRIPTION
This PR addresses two issues:
1.  **Silent Failure on Missing Dependencies**: Previously, if `SMSSearch.exe` was run without its dependencies (e.g., in a Debug build copied to a clean folder), it would crash silently because the JIT compiler failed to load types used in `Main`. I refactored `Program.cs` to isolate dependency-heavy logic into `AppBootstrapper`, allowing `Main` to catch the exception and show a helpful error message.
2.  **Release Build Publishing**: The `PostBuildRelease` target automatically ran a script to publish to GitHub. I added a confirmation prompt to `publish_release.ps1` so the user can build Release locally for testing without accidentally publishing.

---
*PR created automatically by Jules for task [14239354782601042029](https://jules.google.com/task/14239354782601042029) started by @Rapscallion0*