### PR TITLE
Fix Release build runtime crash by removing System.Resources.Extensions

### DIFF
--- a/SMS Search.csproj
+++ b/SMS Search.csproj
@@ -9,7 +9,6 @@
     <ApplicationIcon>SMS Search.ico</ApplicationIcon>
     <RootNamespace>SMS_Search</RootNamespace>
     <AssemblyName>SMSSearch</AssemblyName>
-    <GenerateResourceUsePreserializedResources>true</GenerateResourceUsePreserializedResources>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
   </PropertyGroup>
@@ -56,7 +55,6 @@
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="8.0.0" />
     <PackageReference Include="Dapper" Version="2.1.35" />
-    <PackageReference Include="System.Resources.Extensions" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Removed `System.Resources.Extensions` package reference and the `GenerateResourceUsePreserializedResources` property from `SMS Search.csproj`.
This change forces the use of the standard resource reader/writer native to .NET Framework, preventing the `FileNotFoundException` that occurred when `ILRepack` merged the extensions assembly but resource metadata still pointed to it.
This fixes the runtime crash in Release builds.

---
*PR created automatically by Jules for task [10567933763774744646](https://jules.google.com/task/10567933763774744646) started by @Rapscallion0*