### PR TITLE
Enable High DPI scaling support for Windows Forms

### DIFF
--- a/frmMain.Designer.cs
+++ b/frmMain.Designer.cs
@@ -1154,6 +1154,8 @@ namespace SMS_Search
             // 
             // frmMain
             // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.BackColor = System.Drawing.SystemColors.Control;
             this.ClientSize = new System.Drawing.Size(603, 580);
             this.Controls.Add(this.toolStrip);

--- a/frmPassDecrypt.Designer.cs
+++ b/frmPassDecrypt.Designer.cs
@@ -97,6 +97,8 @@
             // 
             // frmPassDecrypt
             // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.AutoSize = true;
             this.ClientSize = new System.Drawing.Size(538, 102);
             this.Controls.Add(this.btnEncrypt);

--- a/frmUnarchive.Designer.cs
+++ b/frmUnarchive.Designer.cs
@@ -78,6 +78,8 @@ namespace SMS_Search
             // 
             // frmUnarchive
             // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.AllowDrop = true;
             this.BackColor = System.Drawing.Color.DarkRed;
             this.BackgroundImageLayout = System.Windows.Forms.ImageLayout.None;


### PR DESCRIPTION
This change enables proper High DPI scaling support across the application forms. Previously, controls would not resize when the system text scale was increased (e.g., to 125%), causing text to be clipped or squished.

By setting `AutoScaleMode = Font` and the corresponding `AutoScaleDimensions`, Windows Forms will now automatically adjust the size of the form and its controls based on the system font scaling, ensuring a consistent and readable UI at any DPI setting.

Modified files:
- `frmMain.Designer.cs`
- `frmUnarchive.Designer.cs`
- `frmPassDecrypt.Designer.cs`

---
*PR created automatically by Jules for task [2681572616459605488](https://jules.google.com/task/2681572616459605488) started by @Rapscallion0*