### PR TITLE
Fix High DPI Scaling Issues

### DIFF
--- a/Settings/ApplicationSettings.Designer.cs
+++ b/Settings/ApplicationSettings.Designer.cs
@@ -167,7 +167,8 @@ namespace SMS_Search.Settings
             //
             // ApplicationSettings
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.AutoScroll = true;
             this.Controls.Add(this.btnChkUpdate);

--- a/Settings/CleanSqlSettings.Designer.cs
+++ b/Settings/CleanSqlSettings.Designer.cs
@@ -100,7 +100,8 @@ namespace SMS_Search.Settings
             // 
             // CleanSqlSettings
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.Controls.Add(this.chkCopyCleanSql);
             this.Controls.Add(this.lblDescription);

--- a/Settings/DatabaseSettings.Designer.cs
+++ b/Settings/DatabaseSettings.Designer.cs
@@ -179,7 +179,8 @@ namespace SMS_Search.Settings
             // 
             // DatabaseSettings
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.Controls.Add(this.lblDescription);
             this.Controls.Add(this.lblConnStatus);

--- a/Settings/DisplaySettings.Designer.cs
+++ b/Settings/DisplaySettings.Designer.cs
@@ -100,7 +100,8 @@ namespace SMS_Search.Settings
             //
             // DisplaySettings
             //
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.AutoScroll = true;
             this.Controls.Add(this.txtAutoResizeLimit);

--- a/Settings/LauncherSettings.Designer.cs
+++ b/Settings/LauncherSettings.Designer.cs
@@ -128,7 +128,8 @@ namespace SMS_Search.Settings
             // 
             // LauncherSettings
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.Controls.Add(this.lblWarning);
             this.Controls.Add(this.lblDescription);

--- a/Settings/LoggingSettings.Designer.cs
+++ b/Settings/LoggingSettings.Designer.cs
@@ -162,7 +162,8 @@ namespace SMS_Search.Settings
             //
             // LoggingSettings
             //
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.AutoScroll = true;
             this.Controls.Add(this.btnOpenLogFolder);

--- a/Settings/SearchBehaviorSettings.Designer.cs
+++ b/Settings/SearchBehaviorSettings.Designer.cs
@@ -185,7 +185,8 @@ namespace SMS_Search.Settings
             //
             // SearchBehaviorSettings
             //
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.AutoScroll = true;
             this.Controls.Add(this.grpQueryFields);

--- a/Settings/frmConfig.Designer.cs
+++ b/Settings/frmConfig.Designer.cs
@@ -183,6 +183,7 @@ namespace SMS_Search.Settings
             // 
             // frmConfig
             // 
+            this.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.CancelButton = this.btnClose;
@@ -193,7 +194,6 @@ namespace SMS_Search.Settings
             this.Controls.Add(this.btnClose);
             this.Controls.Add(this.btnRevert);
             this.Controls.Add(this.splitConfig);
-            this.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
             this.MaximizeBox = false;
             this.MinimizeBox = false;

--- a/frmMain.Designer.cs
+++ b/frmMain.Designer.cs
@@ -1154,13 +1154,13 @@ namespace SMS_Search
             // 
             // frmMain
             // 
+            this.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.BackColor = System.Drawing.SystemColors.Control;
             this.ClientSize = new System.Drawing.Size(603, 580);
             this.Controls.Add(this.toolStrip);
             this.Controls.Add(this.splitContainer);
-            this.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
             this.KeyPreview = true;
             this.MinimumSize = new System.Drawing.Size(600, 270);

--- a/frmPassDecrypt.Designer.cs
+++ b/frmPassDecrypt.Designer.cs
@@ -97,7 +97,8 @@
             // 
             // frmPassDecrypt
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.AutoSize = true;
             this.ClientSize = new System.Drawing.Size(538, 102);

--- a/frmTestCon.Designer.cs
+++ b/frmTestCon.Designer.cs
@@ -44,7 +44,8 @@ namespace SMS_Search
             label1.Size = new Size(219, 13);
             label1.TabIndex = 0;
             label1.Text = "Testing configuration and SQL connection . . .";
-            AutoScaleDimensions = new SizeF(6f, 13f);
+            Font = new Font("Segoe UI", 9F, FontStyle.Regular, GraphicsUnit.Point, ((byte)(0)));
+            AutoScaleDimensions = new SizeF(7F, 15F);
             AutoScaleMode = AutoScaleMode.Font;
             ClientSize = new Size(243, 34);
             ControlBox = false;

--- a/frmToast.Designer.cs
+++ b/frmToast.Designer.cs
@@ -89,7 +89,8 @@
             // 
             // frmToast
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(300, 60);
             this.Controls.Add(this.lblToastMessage);

--- a/frmUnarchive.Designer.cs
+++ b/frmUnarchive.Designer.cs
@@ -78,7 +78,8 @@ namespace SMS_Search
             // 
             // frmUnarchive
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.AllowDrop = true;
             this.BackColor = System.Drawing.Color.DarkRed;


### PR DESCRIPTION
Standardized all Forms and UserControls to use `Segoe UI, 9pt` and `SizeF(7F, 15F)` scaling. Crucially, updated `.Designer.cs` files to set `this.Font` *before* `this.AutoScaleDimensions` and `this.AutoScaleMode` in `InitializeComponent`, ensuring correct scaling factor calculation at runtime (PerMonitorV2). This fixes the "squished" UI at 125% scaling.

---
*PR created automatically by Jules for task [2707527719418884651](https://jules.google.com/task/2707527719418884651) started by @Rapscallion0*