### PR TITLE
Fix silent search failure and hidden server dropdown

### DIFF
--- a/frmMain.Designer.cs
+++ b/frmMain.Designer.cs
@@ -967,7 +967,7 @@ namespace SMS_Search
             this.tscmbDbServer.Enabled = false;
             this.tscmbDbServer.Name = "tscmbDbServer";
             this.tscmbDbServer.Padding = new System.Windows.Forms.Padding(10, 0, 0, 0);
-            this.tscmbDbServer.Size = new System.Drawing.Size(0, 23);
+            this.tscmbDbServer.Size = new System.Drawing.Size(150, 23);
             this.tscmbDbServer.ToolTipText = "Server";
             // 
             // tscmbDbDatabase

--- a/frmMain.cs
+++ b/frmMain.cs
@@ -698,6 +698,12 @@ namespace SMS_Search
 					tslblInfo.ForeColor = Color.Red;
 				}
 			}
+			else
+			{
+				tslblInfo.Text = "Connection failed!";
+				tslblInfo.ForeColor = Color.Red;
+				MessageBox.Show("Failed to connect to data source.\nPlease check your connection settings.", "SQL connection error", MessageBoxButtons.OK, MessageBoxIcon.Hand);
+			}
 			setTabTextFocus();
 			await setColumnArrayAsync();
 			await setHeadersAsync();


### PR DESCRIPTION
This PR fixes a critical issue where executing a search would fail silently if the database connection was invalid. 

The root cause was identified as:
1. The `tscmbDbServer` control (server dropdown) had a width of 0, making it invisible to the user. This prevented verification of the server name being used.
2. The `btnPopGrid_Click` method performed a connection check (`TestConnectionAsync`) but had no `else` block to handle the `false` result, causing it to exit quietly without updating the UI or notifying the user.

Changes:
- `frmMain.Designer.cs`: Increased `tscmbDbServer` width to 150.
- `frmMain.cs`: Added an `else` block to `btnPopGrid_Click` to show a "Connection failed!" status and a MessageBox with instructions.

---
*PR created automatically by Jules for task [1494607450768881970](https://jules.google.com/task/1494607450768881970) started by @Rapscallion0*