### PR TITLE
Fix results grid auto-hiding on zero results

### DIFF
--- a/frmMain.cs
+++ b/frmMain.cs
@@ -684,14 +684,7 @@ namespace SMS_Search
 					    Height = FormHeightExpanded;
                     }
 				}
-				else
-				{
-					if (dGrd.RowCount < 1)
-					{
-                        splitContainer.Panel2Collapsed = true;
-						Height = FormHeightMin;
-					}
-				}
+
 				if (dGrd.RowCount < 1)
 				{
 					tslblInfo.Text = "Query returned no records!";


### PR DESCRIPTION
Modified the `btnPopGrid_Click` method in `frmMain.cs` to remove the logic that unconditionally set `splitContainer.Panel2Collapsed = true` when `dGrd.RowCount < 1`. The new logic only explicitly expands the panel when rows are found, but does not force it closed if it is already open. This addresses the user's issue where the grid would disappear or remain hidden inappropriately when queries returned zero results.

---
*PR created automatically by Jules for task [14096495507756353598](https://jules.google.com/task/14096495507756353598) started by @Rapscallion0*