### PR TITLE
Move Description Toggle to Context Menu

### DIFF
--- a/SMS Search.csproj
+++ b/SMS Search.csproj
@@ -69,14 +69,7 @@
         <InputAssemblies Include="$(OutputPath)$(AssemblyName).exe" />
         <InputAssemblies Include="@(MergedDlls)" />
     </ItemGroup>
-    <ILRepack
-        Parallel="true"
-        Internalize="true"
-        Union="true"
-        InputAssemblies="@(InputAssemblies)"
-        TargetKind="SameAsPrimaryAssembly"
-        OutputFile="$(OutputPath)$(AssemblyName).Merged.exe"
-    />
+    <ILRepack Parallel="true" Internalize="true" Union="true" InputAssemblies="@(InputAssemblies)" TargetKind="SameAsPrimaryAssembly" OutputFile="$(OutputPath)$(AssemblyName).Merged.exe" />
     <Delete Files="@(MergedDlls)" />
     <Delete Files="$(OutputPath)$(AssemblyName).Merged.exe.config" />
     <Move SourceFiles="$(OutputPath)$(AssemblyName).Merged.exe" DestinationFiles="$(OutputPath)$(AssemblyName).exe" OverwriteReadOnlyFiles="true" />

--- a/Settings/DisplaySettings.Designer.cs
+++ b/Settings/DisplaySettings.Designer.cs
@@ -55,7 +55,7 @@ namespace SMS_Search.Settings
             this.chkDescriptionColumns.Name = "chkDescriptionColumns";
             this.chkDescriptionColumns.Size = new System.Drawing.Size(143, 17);
             this.chkDescriptionColumns.TabIndex = 1;
-            this.chkDescriptionColumns.Text = "Show header description";
+            this.chkDescriptionColumns.Text = "Show description in header";
             this.toolTip1.SetToolTip(this.chkDescriptionColumns, "Show descriptive names in column headers instead of field codes.");
             this.chkDescriptionColumns.UseVisualStyleBackColor = true;
             //

--- a/frmMain.Designer.cs
+++ b/frmMain.Designer.cs
@@ -103,7 +103,6 @@ namespace SMS_Search
         private ToolStripProgressBar tsProgressBar;
         private SplitContainer splitContainer;
         private CheckBox chkLastTransaction;
-        private CheckBox chkToggleDesc;
         private Label lblFilter;
         private TextBox txtGridFilter;
         private Button btnClearFilter;
@@ -205,7 +204,6 @@ namespace SMS_Search
             this.btnClearFilter = new System.Windows.Forms.Button();
             this.txtGridFilter = new System.Windows.Forms.TextBox();
             this.lblFilter = new System.Windows.Forms.Label();
-            this.chkToggleDesc = new System.Windows.Forms.CheckBox();
             ((System.ComponentModel.ISupportInitialize)(this.dGrd)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.picRefresh)).BeginInit();
             this.groupBox1.SuspendLayout();
@@ -1074,7 +1072,6 @@ namespace SMS_Search
             this.splitContainer.Panel2.Controls.Add(this.btnClearFilter);
             this.splitContainer.Panel2.Controls.Add(this.txtGridFilter);
             this.splitContainer.Panel2.Controls.Add(this.lblFilter);
-            this.splitContainer.Panel2.Controls.Add(this.chkToggleDesc);
             this.splitContainer.Panel2.Controls.Add(this.groupBox1);
             this.splitContainer.Panel2.Controls.Add(this.dGrd);
             this.splitContainer.Panel2MinSize = 29;
@@ -1141,17 +1138,6 @@ namespace SMS_Search
             this.lblFilter.Size = new System.Drawing.Size(36, 15);
             this.lblFilter.TabIndex = 10;
             this.lblFilter.Text = "Filter:";
-            // 
-            // chkToggleDesc
-            // 
-            this.chkToggleDesc.Appearance = System.Windows.Forms.Appearance.Button;
-            this.chkToggleDesc.Location = new System.Drawing.Point(87, 4);
-            this.chkToggleDesc.Name = "chkToggleDesc";
-            this.chkToggleDesc.Size = new System.Drawing.Size(77, 23);
-            this.chkToggleDesc.TabIndex = 2;
-            this.chkToggleDesc.Text = "Show Desc.";
-            this.chkToggleDesc.UseVisualStyleBackColor = true;
-            this.chkToggleDesc.CheckedChanged += new System.EventHandler(this.chkToggleDesc_CheckedChanged);
             // 
             // frmMain
             // 

--- a/frmMain.cs
+++ b/frmMain.cs
@@ -71,6 +71,7 @@ namespace SMS_Search
         private Color _matchHighlightColor = Color.Yellow;
         private long _lastTotalMatchCount = 0;
         private bool _showRowNumbers = false;
+        private bool _showDescriptions = false;
 
 		public frmMain(string[] Params)
 		{
@@ -510,11 +511,11 @@ namespace SMS_Search
 
 			if (config.GetValue("GENERAL", "DESCRIPTIONCOLUMNS") == "1")
 			{
-				chkToggleDesc.Checked = true;
+				_showDescriptions = true;
 			}
 			else
 			{
-				chkToggleDesc.Checked = false;
+				_showDescriptions = false;
 			}
 
             string fctFields = config.GetValue("QUERY", "FUNCTION");
@@ -1236,6 +1237,17 @@ namespace SMS_Search
         {
             var menu = new ContextMenuStrip();
 
+            // 0. Toggle Descriptions
+            var itemToggleDesc = menu.Items.Add("Show description in header");
+            itemToggleDesc.Click += async (s, e) =>
+            {
+                _showDescriptions = !_showDescriptions;
+                await setHeadersAsync();
+                setTabTextFocus();
+            };
+
+            menu.Items.Add(new ToolStripSeparator());
+
             // 1. Select all
             var itemSelectAll = menu.Items.Add("Select all");
             itemSelectAll.Click += (s, e) => dGrd.SelectAll();
@@ -1265,6 +1277,14 @@ namespace SMS_Search
             // 8. Export to CSV
             var itemExport = menu.Items.Add("Export results to CSV");
             itemExport.Click += (s, e) => ExportToCsv();
+
+            menu.Opening += (s, e) =>
+            {
+                if (_showDescriptions)
+                    itemToggleDesc.Text = "Show field name in header";
+                else
+                    itemToggleDesc.Text = "Show description in header";
+            };
 
             dGrd.ContextMenuStrip = menu;
             _headerContextMenu = menu; // Reuse for header
@@ -1366,7 +1386,7 @@ namespace SMS_Search
 
 		private async Task setHeadersAsync()
 		{
-            bool showDesc = chkToggleDesc.Checked;
+            bool showDesc = _showDescriptions;
 
             for (int i = 0; i < dGrd.Columns.Count; i++)
             {
@@ -1446,12 +1466,6 @@ namespace SMS_Search
                 col.Width = maxWidth;
             }
         }
-
-		private async void chkToggleDesc_CheckedChanged(object sender, EventArgs e)
-		{
-			await setHeadersAsync();
-			setTabTextFocus();
-		}
 
 		private void frmMain_FormClosing(object sender, FormClosingEventArgs e)
 		{


### PR DESCRIPTION
Replaced the "Show Desc." button in Panel 2 with a context menu item on the grid. 

The new context menu item toggles between "Show description in header" and "Show field name in header" based on the current state. This change only affects the runtime session and does not update the configuration file, ensuring that the user's default preference (set in Settings) is preserved for the next launch.

Also renamed the setting in `DisplaySettings` to "Show description in header" for consistency.

---
*PR created automatically by Jules for task [4506912215569465544](https://jules.google.com/task/4506912215569465544) started by @Rapscallion0*