### PR TITLE
Refactor grid filter to use integrated SearchTextBox

### DIFF
--- a/SMS Search.csproj
+++ b/SMS Search.csproj
@@ -11,6 +11,7 @@
     <AssemblyName>SMSSearch</AssemblyName>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
+    <GenerateResourceUsePreserializedResources>true</GenerateResourceUsePreserializedResources>
   </PropertyGroup>
 
   <Target Name="KillLauncher" BeforeTargets="Build" Condition="'$(OS)' == 'Windows_NT'">
@@ -55,6 +56,7 @@
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="8.0.0" />
     <PackageReference Include="Dapper" Version="2.1.35" />
+    <PackageReference Include="System.Resources.Extensions" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/SearchTextBox.cs
+++ b/SearchTextBox.cs
@@ -1,0 +1,96 @@
+using System;
+using System.ComponentModel;
+using System.Drawing;
+using System.Windows.Forms;
+
+namespace SMS_Search
+{
+    public class SearchTextBox : UserControl
+    {
+        private TextBox txtValue;
+        private Button btnClear;
+
+        public SearchTextBox()
+        {
+            InitializeComponent();
+        }
+
+        [Browsable(true)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
+        public override string Text
+        {
+            get { return txtValue.Text; }
+            set { txtValue.Text = value; }
+        }
+
+        private void InitializeComponent()
+        {
+            this.txtValue = new System.Windows.Forms.TextBox();
+            this.btnClear = new System.Windows.Forms.Button();
+            this.SuspendLayout();
+            //
+            // btnClear
+            //
+            this.btnClear.Dock = System.Windows.Forms.DockStyle.Right;
+            this.btnClear.FlatAppearance.BorderSize = 0;
+            this.btnClear.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.btnClear.Location = new System.Drawing.Point(180, 0);
+            this.btnClear.Name = "btnClear";
+            this.btnClear.Size = new System.Drawing.Size(20, 20);
+            this.btnClear.TabIndex = 1;
+            this.btnClear.Text = "x";
+            this.btnClear.UseVisualStyleBackColor = true;
+            this.btnClear.Cursor = System.Windows.Forms.Cursors.Default;
+            this.btnClear.Visible = false;
+            this.btnClear.Click += new System.EventHandler(this.btnClear_Click);
+            this.btnClear.TabStop = false;
+            //
+            // txtValue
+            //
+            this.txtValue.BorderStyle = System.Windows.Forms.BorderStyle.None;
+            this.txtValue.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.txtValue.Location = new System.Drawing.Point(2, 2);
+            this.txtValue.Name = "txtValue";
+            this.txtValue.Size = new System.Drawing.Size(178, 16);
+            this.txtValue.TabIndex = 0;
+            this.txtValue.TextChanged += new System.EventHandler(this.txtValue_TextChanged);
+            this.txtValue.KeyDown += new System.Windows.Forms.KeyEventHandler(this.txtValue_KeyDown);
+            //
+            // SearchTextBox
+            //
+            this.BackColor = System.Drawing.SystemColors.Window;
+            this.BorderStyle = System.Windows.Forms.BorderStyle.Fixed3D;
+            this.Controls.Add(this.txtValue);
+            this.Controls.Add(this.btnClear);
+            this.Name = "SearchTextBox";
+            this.Padding = new System.Windows.Forms.Padding(2);
+            this.Size = new System.Drawing.Size(200, 23);
+            this.ResumeLayout(false);
+            this.PerformLayout();
+
+        }
+
+        private void txtValue_TextChanged(object sender, EventArgs e)
+        {
+            btnClear.Visible = !string.IsNullOrEmpty(txtValue.Text);
+            OnTextChanged(e);
+        }
+
+        private void btnClear_Click(object sender, EventArgs e)
+        {
+            txtValue.Text = "";
+            txtValue.Focus();
+        }
+
+        private void txtValue_KeyDown(object sender, KeyEventArgs e)
+        {
+            OnKeyDown(e);
+        }
+
+        protected override void OnGotFocus(EventArgs e)
+        {
+            base.OnGotFocus(e);
+            txtValue.Focus();
+        }
+    }
+}

--- a/frmMain.Designer.cs
+++ b/frmMain.Designer.cs
@@ -1,4 +1,4 @@
-﻿using SMS_Search.Properties;
+using SMS_Search.Properties;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
@@ -104,8 +104,7 @@ namespace SMS_Search
         private SplitContainer splitContainer;
         private CheckBox chkLastTransaction;
         private Label lblFilter;
-        private TextBox txtGridFilter;
-        private Button btnClearFilter;
+        private SMS_Search.SearchTextBox txtGridFilter;
         private Label lblMatchCount;
         private Button btnPrevMatch;
         private Button btnNextMatch;
@@ -201,13 +200,13 @@ namespace SMS_Search
             this.btnNextMatch = new System.Windows.Forms.Button();
             this.btnPrevMatch = new System.Windows.Forms.Button();
             this.lblMatchCount = new System.Windows.Forms.Label();
-            this.btnClearFilter = new System.Windows.Forms.Button();
-            this.txtGridFilter = new System.Windows.Forms.TextBox();
+            this.txtGridFilter = new SMS_Search.SearchTextBox();
             this.lblFilter = new System.Windows.Forms.Label();
             ((System.ComponentModel.ISupportInitialize)(this.dGrd)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.picRefresh)).BeginInit();
             this.groupBox1.SuspendLayout();
             this.tabCtl.SuspendLayout();
+            this.tabFct.SuspendLayout();
             this.tabFct.SuspendLayout();
             this.tabTlz.SuspendLayout();
             this.tabFields.SuspendLayout();
@@ -1069,7 +1068,6 @@ namespace SMS_Search
             this.splitContainer.Panel2.Controls.Add(this.btnNextMatch);
             this.splitContainer.Panel2.Controls.Add(this.btnPrevMatch);
             this.splitContainer.Panel2.Controls.Add(this.lblMatchCount);
-            this.splitContainer.Panel2.Controls.Add(this.btnClearFilter);
             this.splitContainer.Panel2.Controls.Add(this.txtGridFilter);
             this.splitContainer.Panel2.Controls.Add(this.lblFilter);
             this.splitContainer.Panel2.Controls.Add(this.groupBox1);
@@ -1112,21 +1110,14 @@ namespace SMS_Search
             this.lblMatchCount.TabIndex = 14;
             this.lblMatchCount.Visible = false;
             // 
-            // btnClearFilter
-            // 
-            this.btnClearFilter.Location = new System.Drawing.Point(251, 34);
-            this.btnClearFilter.Name = "btnClearFilter";
-            this.btnClearFilter.Size = new System.Drawing.Size(23, 23);
-            this.btnClearFilter.TabIndex = 13;
-            this.btnClearFilter.Text = "x";
-            this.btnClearFilter.UseVisualStyleBackColor = true;
-            this.btnClearFilter.Click += new System.EventHandler(this.btnClearFilter_Click);
-            // 
             // txtGridFilter
             // 
+            this.txtGridFilter.BackColor = System.Drawing.SystemColors.Window;
+            this.txtGridFilter.BorderStyle = System.Windows.Forms.BorderStyle.Fixed3D;
             this.txtGridFilter.Location = new System.Drawing.Point(45, 35);
             this.txtGridFilter.Name = "txtGridFilter";
-            this.txtGridFilter.Size = new System.Drawing.Size(200, 23);
+            this.txtGridFilter.Padding = new System.Windows.Forms.Padding(2);
+            this.txtGridFilter.Size = new System.Drawing.Size(229, 23);
             this.txtGridFilter.TabIndex = 11;
             this.txtGridFilter.TextChanged += new System.EventHandler(this.txtGridFilter_TextChanged);
             // 
@@ -1191,7 +1182,3 @@ namespace SMS_Search
         private ToolStripButton ReconnectDB;
     }
 }
-
-
-
-

--- a/frmMain.cs
+++ b/frmMain.cs
@@ -1774,11 +1774,6 @@ namespace SMS_Search
             _filterDebounceTimer.Start();
         }
 
-        private void btnClearFilter_Click(object sender, EventArgs e)
-        {
-            txtGridFilter.Text = "";
-        }
-
         private async void _filterDebounceTimer_Tick(object sender, EventArgs e)
         {
             _filterDebounceTimer.Stop();


### PR DESCRIPTION
Refactor grid filter to use integrated SearchTextBox

Replaced the standard TextBox and external Button for the grid filter with a custom SearchTextBox UserControl.
This control integrates the 'x' clear button inside the text box area (docked right), preventing text from sliding under the button and improving UI consistency. The clear button is only visible when text is present.

- Created SMS_Search.SearchTextBox UserControl.
- Updated frmMain.Designer.cs to use SearchTextBox and removed btnClearFilter.
- Cleaned up frmMain.cs by removing the obsolete btnClearFilter_Click handler.

---
*PR created automatically by Jules for task [10773093200507321710](https://jules.google.com/task/10773093200507321710) started by @Rapscallion0*