### PR TITLE
Fix filter clear button alignment by using icon

### DIFF
--- a/SearchTextBox.cs
+++ b/SearchTextBox.cs
@@ -38,8 +38,11 @@ namespace SMS_Search
             this.btnClear.Name = "btnClear";
             this.btnClear.Size = new System.Drawing.Size(20, 20);
             this.btnClear.TabIndex = 1;
-            this.btnClear.Text = "x";
-            this.btnClear.UseVisualStyleBackColor = true;
+            this.btnClear.Text = "";
+            this.btnClear.BackgroundImage = SMS_Search.Properties.Resources.Round_X;
+            this.btnClear.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Zoom;
+            this.btnClear.BackColor = System.Drawing.SystemColors.Window;
+            this.btnClear.UseVisualStyleBackColor = false;
             this.btnClear.Cursor = System.Windows.Forms.Cursors.Default;
             this.btnClear.Visible = false;
             this.btnClear.Click += new System.EventHandler(this.btnClear_Click);


### PR DESCRIPTION
Replaced the "x" text in the filter clear button with an icon image (`Round_X`) to fix alignment issues. The button now uses a zoom layout for the image and blends seamlessly with the text box background.

---
*PR created automatically by Jules for task [10317522387505191572](https://jules.google.com/task/10317522387505191572) started by @Rapscallion0*