### PR TITLE
Fix System.Resources.Extensions runtime crash

### DIFF
--- a/SMS Search.csproj
+++ b/SMS Search.csproj
@@ -11,7 +11,6 @@
     <AssemblyName>SMSSearch</AssemblyName>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
-    <GenerateResourceUsePreserializedResources>true</GenerateResourceUsePreserializedResources>
   </PropertyGroup>
 
   <Target Name="KillLauncher" BeforeTargets="Build" Condition="'$(OS)' == 'Windows_NT'">
@@ -56,7 +55,6 @@
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="8.0.0" />
     <PackageReference Include="Dapper" Version="2.1.35" />
-    <PackageReference Include="System.Resources.Extensions" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fixes a runtime `FileNotFoundException` by removing `System.Resources.Extensions` and the associated `GenerateResourceUsePreserializedResources` property from `SMS Search.csproj`. This dependency was causing issues with `ILRepack` in the release build.

---
*PR created automatically by Jules for task [8966700639093875506](https://jules.google.com/task/8966700639093875506) started by @Rapscallion0*