### PR TITLE
Implement SQL syntax highlighting

### DIFF
--- a/SqlRichTextBox.cs
+++ b/SqlRichTextBox.cs
@@ -1,0 +1,114 @@
+using System;
+using System.Drawing;
+using System.Runtime.InteropServices;
+using System.Text.RegularExpressions;
+using System.Windows.Forms;
+
+namespace SMS_Search
+{
+    public class SqlRichTextBox : RichTextBox
+    {
+        private const int WM_SETREDRAW = 0x000B;
+        private const int EM_GETEVENTMASK = 0x043b;
+        private const int EM_SETEVENTMASK = 0x0445;
+
+        [DllImport("user32.dll", CharSet = CharSet.Auto)]
+        private static extern IntPtr SendMessage(IntPtr hWnd, int msg, IntPtr wParam, IntPtr lParam);
+
+        private bool _isHighlighting = false;
+
+        // SSMS-like Colors
+        private readonly Color ColorKeyword = Color.Blue;
+        private readonly Color ColorString = Color.Red;
+        private readonly Color ColorComment = Color.Green;
+        private readonly Color ColorNormal = Color.Black;
+
+        public SqlRichTextBox()
+        {
+            // Set Font to Consolas or Courier New
+            Font font = new Font("Consolas", 9.75f, FontStyle.Regular);
+            if (font.Name != "Consolas")
+            {
+                font = new Font("Courier New", 9.75f, FontStyle.Regular);
+            }
+            this.Font = font;
+
+            // Allow tab indentation
+            this.AcceptsTab = true;
+        }
+
+        protected override void OnTextChanged(EventArgs e)
+        {
+            if (_isHighlighting)
+                return;
+
+            base.OnTextChanged(e);
+            HighlightSyntax();
+        }
+
+        public void HighlightSyntax()
+        {
+            if (_isHighlighting) return;
+            _isHighlighting = true;
+
+            // Stop Redraw and Events to prevent flickering and scrolling
+            IntPtr eventMask = SendMessage(this.Handle, EM_GETEVENTMASK, IntPtr.Zero, IntPtr.Zero);
+            SendMessage(this.Handle, WM_SETREDRAW, (IntPtr)0, IntPtr.Zero);
+
+            int selectionStart = this.SelectionStart;
+            int selectionLength = this.SelectionLength;
+
+            try
+            {
+                // Reset text color to Normal
+                this.SelectAll();
+                this.SelectionColor = ColorNormal;
+
+                string text = this.Text;
+
+                // Combined Regex for efficiency and correct precedence
+                // Group 1: Comment (--... or /*...*/)
+                // Group 2: String ('...')
+                // Group 3: Keyword
+                string pattern = @"(?<Comment>--.*$|/\*[\s\S]*?\*/)|(?<String>'([^']|'')*')|(?<Keyword>\b(SELECT|FROM|WHERE|AND|OR|ORDER BY|GROUP BY|INSERT|UPDATE|DELETE|JOIN|LEFT|RIGHT|INNER|OUTER|TOP|DISTINCT|AS|CASE|WHEN|THEN|ELSE|END|IS|NULL|NOT|IN|EXISTS|LIKE|HAVING|UNION|ALL|CROSS|FULL|DEFAULT|VALUES|SET|CREATE|ALTER|DROP|TABLE|VIEW|INDEX|PROCEDURE|TRIGGER|FUNCTION|DECLARE|EXEC|EXECUTE)\b)";
+
+                Regex regex = new Regex(pattern, RegexOptions.Multiline | RegexOptions.IgnoreCase | RegexOptions.ExplicitCapture);
+
+                foreach (Match m in regex.Matches(text))
+                {
+                    this.Select(m.Index, m.Length);
+
+                    if (m.Groups["Comment"].Success)
+                    {
+                        this.SelectionColor = ColorComment;
+                    }
+                    else if (m.Groups["String"].Success)
+                    {
+                        this.SelectionColor = ColorString;
+                    }
+                    else if (m.Groups["Keyword"].Success)
+                    {
+                        this.SelectionColor = ColorKeyword;
+                    }
+                }
+            }
+            catch
+            {
+                // Ignore errors during highlighting
+            }
+            finally
+            {
+                // Restore selection
+                this.Select(selectionStart, selectionLength);
+                this.SelectionColor = ColorNormal; // Ensure subsequent typing is normal color
+
+                // Restore Redraw
+                SendMessage(this.Handle, EM_SETEVENTMASK, IntPtr.Zero, eventMask);
+                SendMessage(this.Handle, WM_SETREDRAW, (IntPtr)1, IntPtr.Zero);
+                this.Invalidate();
+
+                _isHighlighting = false;
+            }
+        }
+    }
+}

--- a/frmMain.Designer.cs
+++ b/frmMain.Designer.cs
@@ -46,11 +46,11 @@ namespace SMS_Search
         private RadioButton rdbDescFct;
         private TextBox txtDescFct;
         private TextBox txtNumFct;
-        private TextBox txtCustSqlFct;
+        private SMS_Search.SqlRichTextBox txtCustSqlFct;
         private RadioButton rdbCustSqlTlz;
         private RadioButton rdbNumTlz;
         private Button btnBuildQryTlz;
-        private TextBox txtCustSqlTlz;
+        private SMS_Search.SqlRichTextBox txtCustSqlTlz;
         private Button btnClearTlz;
         private TextBox txtNumTlz;
         private TextBox txtDescTlz;
@@ -70,7 +70,7 @@ namespace SMS_Search
         private TextBox txtNumFld;
         private Button btnBuildQryFld;
         private Button btnClearFld;
-        private TextBox txtCustSqlFld;
+        private SMS_Search.SqlRichTextBox txtCustSqlFld;
         private Label label6;
         private RadioButton rdbTableFld;
         private ComboBox cmbTableFld;
@@ -139,14 +139,14 @@ namespace SMS_Search
             this.label1 = new System.Windows.Forms.Label();
             this.rdbCustSqlFct = new System.Windows.Forms.RadioButton();
             this.rdbNumFct = new System.Windows.Forms.RadioButton();
-            this.txtCustSqlFct = new System.Windows.Forms.TextBox();
+            this.txtCustSqlFct = new SMS_Search.SqlRichTextBox();
             this.btnClearFct = new System.Windows.Forms.Button();
             this.txtNumFct = new System.Windows.Forms.TextBox();
             this.txtDescFct = new System.Windows.Forms.TextBox();
             this.rdbDescFct = new System.Windows.Forms.RadioButton();
             this.rdbCustSqlTlz = new System.Windows.Forms.RadioButton();
             this.rdbNumTlz = new System.Windows.Forms.RadioButton();
-            this.txtCustSqlTlz = new System.Windows.Forms.TextBox();
+            this.txtCustSqlTlz = new SMS_Search.SqlRichTextBox();
             this.btnClearTlz = new System.Windows.Forms.Button();
             this.txtNumTlz = new System.Windows.Forms.TextBox();
             this.txtDescTlz = new System.Windows.Forms.TextBox();
@@ -175,7 +175,7 @@ namespace SMS_Search
             this.txtDescFld = new System.Windows.Forms.TextBox();
             this.txtNumFld = new System.Windows.Forms.TextBox();
             this.btnClearFld = new System.Windows.Forms.Button();
-            this.txtCustSqlFld = new System.Windows.Forms.TextBox();
+            this.txtCustSqlFld = new SMS_Search.SqlRichTextBox();
             this.label6 = new System.Windows.Forms.Label();
             this.notifyIcon = new System.Windows.Forms.NotifyIcon(this.components);
             this.contextMenuStripNotify = new System.Windows.Forms.ContextMenuStrip(this.components);
@@ -451,7 +451,7 @@ namespace SMS_Search
             this.txtCustSqlFct.Location = new System.Drawing.Point(97, 59);
             this.txtCustSqlFct.Multiline = true;
             this.txtCustSqlFct.Name = "txtCustSqlFct";
-            this.txtCustSqlFct.ScrollBars = System.Windows.Forms.ScrollBars.Vertical;
+            this.txtCustSqlFct.ScrollBars = System.Windows.Forms.RichTextBoxScrollBars.Vertical;
             this.txtCustSqlFct.Size = new System.Drawing.Size(483, 77);
             this.txtCustSqlFct.TabIndex = 4;
             this.txtCustSqlFct.Enter += new System.EventHandler(this.txtSqlFct_Enter);
@@ -529,7 +529,7 @@ namespace SMS_Search
             this.txtCustSqlTlz.Location = new System.Drawing.Point(97, 59);
             this.txtCustSqlTlz.Multiline = true;
             this.txtCustSqlTlz.Name = "txtCustSqlTlz";
-            this.txtCustSqlTlz.ScrollBars = System.Windows.Forms.ScrollBars.Vertical;
+            this.txtCustSqlTlz.ScrollBars = System.Windows.Forms.RichTextBoxScrollBars.Vertical;
             this.txtCustSqlTlz.Size = new System.Drawing.Size(483, 49);
             this.txtCustSqlTlz.TabIndex = 4;
             this.txtCustSqlTlz.Enter += new System.EventHandler(this.txtCustSqlTlz_Enter);
@@ -886,7 +886,7 @@ namespace SMS_Search
             this.txtCustSqlFld.Location = new System.Drawing.Point(97, 84);
             this.txtCustSqlFld.Multiline = true;
             this.txtCustSqlFld.Name = "txtCustSqlFld";
-            this.txtCustSqlFld.ScrollBars = System.Windows.Forms.ScrollBars.Vertical;
+            this.txtCustSqlFld.ScrollBars = System.Windows.Forms.RichTextBoxScrollBars.Vertical;
             this.txtCustSqlFld.Size = new System.Drawing.Size(484, 24);
             this.txtCustSqlFld.TabIndex = 6;
             this.txtCustSqlFld.Enter += new System.EventHandler(this.txtCustSqlFld_Enter);


### PR DESCRIPTION
Replaced standard TextBox controls with a custom SqlRichTextBox control that provides SSMS-style syntax highlighting (Keywords, Strings, Comments) for the three custom SQL input fields in the main form.

- Created `SqlRichTextBox.cs` inheriting from `RichTextBox`.
- Implemented `HighlightSyntax` using Regex for efficient coloring.
- Used `WM_SETREDRAW` to prevent flickering.
- Updated `frmMain.Designer.cs` to use the new control and `RichTextBoxScrollBars`.

---
*PR created automatically by Jules for task [9681510249476292910](https://jules.google.com/task/9681510249476292910) started by @Rapscallion0*