### PR TITLE
Update Function/Totalizer search to return full set on empty input

### DIFF
--- a/QueryBuilder.cs
+++ b/QueryBuilder.cs
@@ -122,18 +122,24 @@ GROUP BY
                 sql = $"Select {_tlzFields} FROM TLZ_TAB";
                 if (criteria.Type == SearchType.Number)
                 {
-                    string val = criteria.Value;
-                    HandleWildcards(ref val, out string op);
-                    sql += $" WHERE F1034 {op} @Val";
-                    p.Add("Val", val);
+                    if (!string.IsNullOrEmpty(criteria.Value))
+                    {
+                        string val = criteria.Value;
+                        HandleWildcards(ref val, out string op);
+                        sql += $" WHERE F1034 {op} @Val";
+                        p.Add("Val", val);
+                    }
                 }
                 else if (criteria.Type == SearchType.Description)
                 {
-                     string val = criteria.Value;
-                     if (criteria.AnyMatch) val = $"*{val}*";
-                     HandleWildcards(ref val, out string op);
-                     sql += $" WHERE F1039 {op} @Val";
-                     p.Add("Val", val);
+                    if (!string.IsNullOrEmpty(criteria.Value))
+                    {
+                        string val = criteria.Value;
+                        if (criteria.AnyMatch) val = $"*{val}*";
+                        HandleWildcards(ref val, out string op);
+                        sql += $" WHERE F1039 {op} @Val";
+                        p.Add("Val", val);
+                    }
                 }
                 else if (criteria.Type == SearchType.CustomSql)
                 {
@@ -145,18 +151,24 @@ GROUP BY
                 sql = $"Select {_fctFields} FROM FCT_TAB";
                 if (criteria.Type == SearchType.Number)
                 {
-                    string val = criteria.Value;
-                    HandleWildcards(ref val, out string op);
-                    sql += $" WHERE F1063 {op} @Val";
-                    p.Add("Val", val);
+                    if (!string.IsNullOrEmpty(criteria.Value))
+                    {
+                        string val = criteria.Value;
+                        HandleWildcards(ref val, out string op);
+                        sql += $" WHERE F1063 {op} @Val";
+                        p.Add("Val", val);
+                    }
                 }
                 else if (criteria.Type == SearchType.Description)
                 {
-                     string val = criteria.Value;
-                     if (criteria.AnyMatch) val = $"*{val}*";
-                     HandleWildcards(ref val, out string op);
-                     sql += $" WHERE F1064 {op} @Val";
-                     p.Add("Val", val);
+                    if (!string.IsNullOrEmpty(criteria.Value))
+                    {
+                        string val = criteria.Value;
+                        if (criteria.AnyMatch) val = $"*{val}*";
+                        HandleWildcards(ref val, out string op);
+                        sql += $" WHERE F1064 {op} @Val";
+                        p.Add("Val", val);
+                    }
                 }
                 else if (criteria.Type == SearchType.CustomSql)
                 {


### PR DESCRIPTION
Updated the search logic in `QueryBuilder.cs` for Function and Totalizer tabs. When the search type is Number or Description and the input value is strictly empty (not including whitespace), the generated SQL now omits the `WHERE` clause, resulting in a return of all records. This matches the user's requirement to return the full result set when no filter is provided. Verified logic with a standalone test script covering various scenarios (empty, whitespace, normal values).

---
*PR created automatically by Jules for task [14756202588262615868](https://jules.google.com/task/14756202588262615868) started by @Rapscallion0*