### PR TITLE
Enhance SQL syntax highlighting to bold tables and aliases

### DIFF
--- a/SqlRichTextBox.cs
+++ b/SqlRichTextBox.cs
@@ -58,36 +58,99 @@ namespace SMS_Search
             int selectionStart = this.SelectionStart;
             int selectionLength = this.SelectionLength;
 
+            Font regularFont = null;
+            Font boldFont = null;
+
             try
             {
-                // Reset text color to Normal
+                // Create font objects once to optimize resource usage
+                regularFont = new Font(this.Font, FontStyle.Regular);
+                boldFont = new Font(this.Font, FontStyle.Bold);
+
+                // Reset text color to Normal and Font to Regular
                 this.SelectAll();
                 this.SelectionColor = ColorNormal;
+                this.SelectionFont = regularFont;
 
                 string text = this.Text;
+
+                // Keywords list (Added INTO, ON)
+                string keywordsList = "SELECT|FROM|WHERE|AND|OR|ORDER BY|GROUP BY|INSERT|UPDATE|DELETE|JOIN|LEFT|RIGHT|INNER|OUTER|TOP|DISTINCT|AS|CASE|WHEN|THEN|ELSE|END|IS|NULL|NOT|IN|EXISTS|LIKE|HAVING|UNION|ALL|CROSS|FULL|DEFAULT|VALUES|SET|CREATE|ALTER|DROP|TABLE|VIEW|INDEX|PROCEDURE|TRIGGER|FUNCTION|DECLARE|EXEC|EXECUTE|INTO|ON";
+
+                // Triggers for Table/Alias bolding
+                string tableTriggers = "FROM|JOIN|UPDATE|INTO";
+
+                // Exclusion list for Aliases (Keywords + ORDER/GROUP split from ORDER BY/GROUP BY)
+                // We split "ORDER BY" -> "ORDER" because "ORDER" is the start of the keyword, so it shouldn't be an alias.
+                string aliasExclusions = keywordsList.Replace("ORDER BY", "ORDER").Replace("GROUP BY", "GROUP");
+
+                // Robust Identifier Patterns
+                // Part: [Bracketed] OR "Quoted" OR SimpleWord
+                string idPart = @"(?:\[[^\]]+\]|""[^""]+""|[\w]+)";
+                // Table: Part (. Part)*
+                string tablePattern = idPart + @"(?:\." + idPart + @")*";
+                // Alias: Part
+                string aliasPattern = idPart;
 
                 // Combined Regex for efficiency and correct precedence
                 // Group 1: Comment (--... or /*...*/)
                 // Group 2: String ('...')
-                // Group 3: Keyword
-                string pattern = @"(?<Comment>--.*$|/\*[\s\S]*?\*/)|(?<String>'([^']|'')*')|(?<Keyword>\b(SELECT|FROM|WHERE|AND|OR|ORDER BY|GROUP BY|INSERT|UPDATE|DELETE|JOIN|LEFT|RIGHT|INNER|OUTER|TOP|DISTINCT|AS|CASE|WHEN|THEN|ELSE|END|IS|NULL|NOT|IN|EXISTS|LIKE|HAVING|UNION|ALL|CROSS|FULL|DEFAULT|VALUES|SET|CREATE|ALTER|DROP|TABLE|VIEW|INDEX|PROCEDURE|TRIGGER|FUNCTION|DECLARE|EXEC|EXECUTE)\b)";
+                // Group 3: TableDefinition (Trigger + Table + Optional Alias)
+                // Group 4: Keyword
+
+                string pattern =
+                    @"(?<Comment>--.*$|/\*[\s\S]*?\*/)|" +
+                    @"(?<String>'([^']|'')*')|" +
+                    @"(?<TableDef>\b(?<Trigger>" + tableTriggers + @")\s+(?<Table>" + tablePattern + @")(?:\s+(?:(?<As>AS)\s+)?(?<Alias>(?!\b(" + aliasExclusions + @")\b)" + aliasPattern + @"))?)|" +
+                    @"(?<Keyword>\b(" + keywordsList + @")\b)";
 
                 Regex regex = new Regex(pattern, RegexOptions.Multiline | RegexOptions.IgnoreCase | RegexOptions.ExplicitCapture);
 
                 foreach (Match m in regex.Matches(text))
                 {
-                    this.Select(m.Index, m.Length);
-
                     if (m.Groups["Comment"].Success)
                     {
+                        this.Select(m.Index, m.Length);
                         this.SelectionColor = ColorComment;
                     }
                     else if (m.Groups["String"].Success)
                     {
+                        this.Select(m.Index, m.Length);
                         this.SelectionColor = ColorString;
+                    }
+                    else if (m.Groups["TableDef"].Success)
+                    {
+                        // 1. Trigger (FROM, JOIN, etc) - Blue
+                        Group gTrigger = m.Groups["Trigger"];
+                        if(gTrigger.Success) {
+                            this.Select(gTrigger.Index, gTrigger.Length);
+                            this.SelectionColor = ColorKeyword;
+                        }
+
+                        // 2. Table Name - Bold
+                        Group gTable = m.Groups["Table"];
+                        if(gTable.Success) {
+                            this.Select(gTable.Index, gTable.Length);
+                            this.SelectionFont = boldFont;
+                        }
+
+                        // 3. AS - Blue
+                        Group gAs = m.Groups["As"];
+                        if(gAs.Success) {
+                            this.Select(gAs.Index, gAs.Length);
+                            this.SelectionColor = ColorKeyword;
+                        }
+
+                        // 4. Alias - Bold
+                        Group gAlias = m.Groups["Alias"];
+                        if(gAlias.Success) {
+                            this.Select(gAlias.Index, gAlias.Length);
+                            this.SelectionFont = boldFont;
+                        }
                     }
                     else if (m.Groups["Keyword"].Success)
                     {
+                        this.Select(m.Index, m.Length);
                         this.SelectionColor = ColorKeyword;
                     }
                 }
@@ -100,7 +163,14 @@ namespace SMS_Search
             {
                 // Restore selection
                 this.Select(selectionStart, selectionLength);
-                this.SelectionColor = ColorNormal; // Ensure subsequent typing is normal color
+                this.SelectionColor = ColorNormal;
+                // Ensure subsequent typing is normal
+                if (regularFont != null)
+                    this.SelectionFont = regularFont;
+
+                // Dispose fonts
+                if (regularFont != null) regularFont.Dispose();
+                if (boldFont != null) boldFont.Dispose();
 
                 // Restore Redraw
                 SendMessage(this.Handle, EM_SETEVENTMASK, IntPtr.Zero, eventMask);


### PR DESCRIPTION
This change updates the custom `SqlRichTextBox` control to improve readability of SQL queries by bolding table names and aliases. 

Key changes:
1.  **Regex Update:** The syntax highlighting regex was completely rewritten to support context-aware formatting. A new `TableDefinition` group captures the structure `TRIGGER TABLE [AS] [ALIAS]`.
2.  **Keyword Expansion:** Added `INTO` and `ON` to the keyword list to ensure they are highlighted correctly and respected as delimiters.
3.  **Identifier Support:** Added support for multi-part identifiers (e.g., `[Schema].[Table]`) and quoted identifiers.
4.  **Alias Safety:** Implemented strict exclusion logic to prevent SQL keywords (like `WHERE`, `ON`, `ORDER BY`) from being visually identified as table aliases when they follow a table name.
5.  **Performance:** Refactored the `HighlightSyntax` method to instantiate `Bold` and `Regular` fonts once per pass, rather than per match, optimizing resource usage.

---
*PR created automatically by Jules for task [9880566366699111064](https://jules.google.com/task/9880566366699111064) started by @Rapscallion0*