### PR TITLE
Fix MSB3677 error by deleting existing exe before ILRepack move

### DIFF
--- a/SMS Search.csproj
+++ b/SMS Search.csproj
@@ -72,6 +72,7 @@
     <ILRepack Parallel="true" Internalize="true" Union="true" InputAssemblies="@(InputAssemblies)" TargetKind="SameAsPrimaryAssembly" OutputFile="$(OutputPath)$(AssemblyName).Merged.exe" />
     <Delete Files="@(MergedDlls)" />
     <Delete Files="$(OutputPath)$(AssemblyName).Merged.exe.config" />
+    <Delete Files="$(OutputPath)$(AssemblyName).exe" />
     <Move SourceFiles="$(OutputPath)$(AssemblyName).Merged.exe" DestinationFiles="$(OutputPath)$(AssemblyName).exe" OverwriteReadOnlyFiles="true" />
   </Target>
 


### PR DESCRIPTION
Resolved a build failure (`MSB3677`) occurring during the Release configuration. The `RunILRepack` target attempts to move the merged executable (`SMSSearch.Merged.exe`) to `SMSSearch.exe`. If `SMSSearch.exe` already exists (which it does, as it's the build output), the Move task fails on some systems. 

Changes:
- Modified `SMS Search.csproj` to explicitly delete `$(OutputPath)$(AssemblyName).exe` immediately before the `Move` operation.
- This ensures the destination is clear, allowing the move to succeed.
- Verified that subsequent build steps (like `PostBuildRelease`) are unaffected as they run after this target is complete and the file is in place.

---
*PR created automatically by Jules for task [14975688759621237907](https://jules.google.com/task/14975688759621237907) started by @Rapscallion0*