### PR TITLE
Add missing 'Saved!' feedback to Display and Search settings

### DIFF
--- a/Settings/DisplaySettings.cs
+++ b/Settings/DisplaySettings.cs
@@ -70,6 +70,8 @@ namespace SMS_Search.Settings
             if (!_isLoaded || _config == null) return;
             _config.SetValue(section, key, value);
             _config.Save();
+
+            (this.ParentForm as frmConfig)?.FlashSaved();
         }
     }
 }

--- a/Settings/SearchBehaviorSettings.cs
+++ b/Settings/SearchBehaviorSettings.cs
@@ -102,6 +102,8 @@ namespace SMS_Search.Settings
             if (!_isLoaded || _config == null) return;
             _config.SetValue(section, key, value);
             _config.Save();
+
+            (this.ParentForm as frmConfig)?.FlashSaved();
         }
     }
 }


### PR DESCRIPTION
Added `(this.ParentForm as frmConfig)?.FlashSaved();` to `SaveSetting` in `DisplaySettings.cs` and `SearchBehaviorSettings.cs`. This triggers the green "Saved!" label on the parent configuration form whenever a setting is modified in these user controls.

---
*PR created automatically by Jules for task [7134492270471513277](https://jules.google.com/task/7134492270471513277) started by @Rapscallion0*