### PR TITLE
Fix build failure by unregistering service and releasing file locks

### DIFF
--- a/SMS Search.csproj
+++ b/SMS Search.csproj
@@ -13,10 +13,8 @@
     <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
   </PropertyGroup>
 
-  <Target Name="KillLauncher" BeforeTargets="Build" Condition="'$(OS)' == 'Windows_NT'">
-    <Exec Command="taskkill /F /IM &quot;SMS Search Launcher.exe&quot; 2&gt;nul || exit 0" />
-    <Exec Command="taskkill /F /IM &quot;SMSSearchLauncher.exe&quot; 2&gt;nul || exit 0" />
-    <Exec Command="taskkill /F /IM &quot;SMSSearch.exe&quot; 2&gt;nul || exit 0" />
+  <Target Name="PreBuildServiceCleanup" BeforeTargets="Build" Condition="'$(OS)' == 'Windows_NT'">
+    <Exec Command="powershell.exe -ExecutionPolicy Bypass -NoProfile -NonInteractive -Command &quot;$startup = [System.Environment]::GetFolderPath([System.Environment+SpecialFolder]::Startup); $lnk = Join-Path $startup 'SMSSearchLauncher.lnk'; $marker = '$(ProjectDir)$(IntermediateOutputPath)service_was_registered.marker'; if (Test-Path $lnk) { New-Item -ItemType File -Path $marker -Force | Out-Null; Remove-Item $lnk -Force -ErrorAction SilentlyContinue; } Stop-Process -Name 'SMSSearch','SMSSearchLauncher','SMS Search Launcher' -Force -ErrorAction SilentlyContinue&quot;" />
   </Target>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
@@ -81,8 +79,8 @@
      <Exec Command="powershell.exe -ExecutionPolicy Bypass -NoProfile -NonInteractive -File &quot;$(MSBuildProjectDirectory)\publish_release.ps1&quot; -AssemblyInfoPath &quot;$(MSBuildProjectDirectory)\Properties\AssemblyInfo.cs&quot; -ExePath &quot;$(TargetPath)&quot;" />
   </Target>
 
-  <Target Name="RestartListener" AfterTargets="Build" Condition="'$(OS)' == 'Windows_NT'">
-    <Exec Command="powershell.exe -ExecutionPolicy Bypass -NoProfile -NonInteractive -Command &quot;$s = [System.Environment]::GetFolderPath([System.Environment+SpecialFolder]::Startup); $p = Join-Path $s 'SMSSearchLauncher.lnk'; if (Test-Path $p) { Start-Process -FilePath '$(TargetPath)' -ArgumentList '--listener' }&quot;" />
+  <Target Name="PostBuildServiceRestore" AfterTargets="Build" Condition="'$(OS)' == 'Windows_NT'">
+    <Exec Command="powershell.exe -ExecutionPolicy Bypass -NoProfile -NonInteractive -Command &quot;$marker = '$(ProjectDir)$(IntermediateOutputPath)service_was_registered.marker'; if (Test-Path $marker) { $startup = [System.Environment]::GetFolderPath([System.Environment+SpecialFolder]::Startup); $lnk = Join-Path $startup 'SMSSearchLauncher.lnk'; $WshShell = New-Object -comObject WScript.Shell; $Shortcut = $WshShell.CreateShortcut($lnk); $Shortcut.TargetPath = '$(TargetPath)'; $Shortcut.Arguments = '--listener'; $Shortcut.WorkingDirectory = '$(TargetDir)'; $Shortcut.Save(); Start-Process -FilePath '$(TargetPath)' -ArgumentList '--listener'; Remove-Item $marker -Force -ErrorAction SilentlyContinue; }&quot;" />
   </Target>
 
 </Project>


### PR DESCRIPTION
Modified `SMS Search.csproj` to implement a robust Pre-Build and Post-Build service management workflow.
- **PreBuildServiceCleanup**: Runs before the build to check if the `SMSSearchLauncher` service is registered. If so, it creates a marker file (`service_was_registered.marker`) in the intermediate output directory, unregisters the service (removes the shortcut), and forcefully terminates `SMSSearch` processes to release file locks.
- **PostBuildServiceRestore**: Runs after the build (and after ILRepack) to check for the marker file. If found, it re-registers the service (creates the shortcut) and restarts the listener process, ensuring the developer's environment is restored to its previous state.

This resolves the issue where the running service locked `SMSSearch.exe`, causing build failures.

---
*PR created automatically by Jules for task [4615731163180344882](https://jules.google.com/task/4615731163180344882) started by @Rapscallion0*