### PR TITLE
Fix MSB3073 build error due to PowerShell variable expansion

### DIFF
--- a/SMS Search.csproj
+++ b/SMS Search.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <Target Name="PreBuildServiceCleanup" BeforeTargets="Build" Condition="'$(OS)' == 'Windows_NT'">
-    <Exec Command="powershell.exe -ExecutionPolicy Bypass -NoProfile -NonInteractive -Command &quot;$startup = [System.Environment]::GetFolderPath([System.Environment+SpecialFolder]::Startup); $lnk = Join-Path $startup 'SMSSearchLauncher.lnk'; $marker = '$(ProjectDir)$(IntermediateOutputPath)service_was_registered.marker'; if (Test-Path $lnk) { New-Item -ItemType File -Path $marker -Force | Out-Null; Remove-Item $lnk -Force -ErrorAction SilentlyContinue; } Stop-Process -Name 'SMSSearch','SMSSearchLauncher','SMS Search Launcher' -Force -ErrorAction SilentlyContinue&quot;" />
+    <Exec Command="powershell.exe -ExecutionPolicy Bypass -NoProfile -NonInteractive -Command '$startup = [System.Environment]::GetFolderPath([System.Environment+SpecialFolder]::Startup); $lnk = Join-Path $startup ''SMSSearchLauncher.lnk''; $marker = ''$(ProjectDir)$(IntermediateOutputPath)service_was_registered.marker''; if (Test-Path $lnk) { New-Item -ItemType File -Path $marker -Force | Out-Null; Remove-Item $lnk -Force -ErrorAction SilentlyContinue; } Stop-Process -Name ''SMSSearch'',''SMSSearchLauncher'',''SMS Search Launcher'' -Force -ErrorAction SilentlyContinue'" />
   </Target>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
@@ -80,7 +80,7 @@
   </Target>
 
   <Target Name="PostBuildServiceRestore" AfterTargets="Build" Condition="'$(OS)' == 'Windows_NT'">
-    <Exec Command="powershell.exe -ExecutionPolicy Bypass -NoProfile -NonInteractive -Command &quot;$marker = '$(ProjectDir)$(IntermediateOutputPath)service_was_registered.marker'; if (Test-Path $marker) { $startup = [System.Environment]::GetFolderPath([System.Environment+SpecialFolder]::Startup); $lnk = Join-Path $startup 'SMSSearchLauncher.lnk'; $WshShell = New-Object -comObject WScript.Shell; $Shortcut = $WshShell.CreateShortcut($lnk); $Shortcut.TargetPath = '$(TargetPath)'; $Shortcut.Arguments = '--listener'; $Shortcut.WorkingDirectory = '$(TargetDir)'; $Shortcut.Save(); Start-Process -FilePath '$(TargetPath)' -ArgumentList '--listener'; Remove-Item $marker -Force -ErrorAction SilentlyContinue; }&quot;" />
+    <Exec Command="powershell.exe -ExecutionPolicy Bypass -NoProfile -NonInteractive -Command '$marker = ''$(ProjectDir)$(IntermediateOutputPath)service_was_registered.marker''; if (Test-Path $marker) { $startup = [System.Environment]::GetFolderPath([System.Environment+SpecialFolder]::Startup); $lnk = Join-Path $startup ''SMSSearchLauncher.lnk''; $WshShell = New-Object -comObject WScript.Shell; $Shortcut = $WshShell.CreateShortcut($lnk); $Shortcut.TargetPath = ''$(TargetPath)''; $Shortcut.Arguments = ''--listener''; $Shortcut.WorkingDirectory = ''$(TargetDir)''; $Shortcut.Save(); Start-Process -FilePath ''$(TargetPath)'' -ArgumentList ''--listener''; Remove-Item $marker -Force -ErrorAction SilentlyContinue; }'" />
   </Target>
 
 </Project>


### PR DESCRIPTION
The build process was failing with error `MSB3073` because the PowerShell commands in `PreBuildServiceCleanup` and `PostBuildServiceRestore` targets were wrapped in double quotes. This caused the shell to attempt to expand PowerShell variables like `$startup` and `$lnk` before the command was passed to PowerShell, resulting in empty values and syntax errors (e.g., `The term '=' is not recognized`).

This change modifies the `Exec` tasks to use single quotes (`&apos;`) for the `-Command` argument, ensuring that the command string is passed literally to PowerShell. Internal single quotes (used for file names and paths) are escaped by doubling them (`''`), adhering to PowerShell syntax for single-quoted strings. This ensures that variables are evaluated by the PowerShell runtime as intended.

---
*PR created automatically by Jules for task [10738995964923581514](https://jules.google.com/task/10738995964923581514) started by @Rapscallion0*