### PR TITLE
Fix MSB3073 build error by externalizing PowerShell scripts

### DIFF
--- a/PostBuildServiceRestore.ps1
+++ b/PostBuildServiceRestore.ps1
@@ -1,0 +1,21 @@
+param(
+    [string]$MarkerPath,
+    [string]$TargetPath,
+    [string]$TargetDir
+)
+
+if (Test-Path $MarkerPath) {
+    $startup = [System.Environment]::GetFolderPath([System.Environment+SpecialFolder]::Startup)
+    $lnk = Join-Path $startup 'SMSSearchLauncher.lnk'
+
+    $WshShell = New-Object -comObject WScript.Shell
+    $Shortcut = $WshShell.CreateShortcut($lnk)
+    $Shortcut.TargetPath = $TargetPath
+    $Shortcut.Arguments = '--listener'
+    $Shortcut.WorkingDirectory = $TargetDir
+    $Shortcut.Save()
+
+    Start-Process -FilePath $TargetPath -ArgumentList '--listener'
+
+    Remove-Item $MarkerPath -Force -ErrorAction SilentlyContinue
+}

--- a/PreBuildServiceCleanup.ps1
+++ b/PreBuildServiceCleanup.ps1
@@ -1,0 +1,13 @@
+param(
+    [string]$MarkerPath
+)
+
+$startup = [System.Environment]::GetFolderPath([System.Environment+SpecialFolder]::Startup)
+$lnk = Join-Path $startup 'SMSSearchLauncher.lnk'
+
+if (Test-Path $lnk) {
+    New-Item -ItemType File -Path $MarkerPath -Force | Out-Null
+    Remove-Item $lnk -Force -ErrorAction SilentlyContinue
+}
+
+Stop-Process -Name 'SMSSearch','SMSSearchLauncher','SMS Search Launcher' -Force -ErrorAction SilentlyContinue

--- a/SMS Search.csproj
+++ b/SMS Search.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <Target Name="PreBuildServiceCleanup" BeforeTargets="Build" Condition="'$(OS)' == 'Windows_NT'">
-    <Exec Command="powershell.exe -ExecutionPolicy Bypass -NoProfile -NonInteractive -Command '$startup = [System.Environment]::GetFolderPath([System.Environment+SpecialFolder]::Startup); $lnk = Join-Path $startup ''SMSSearchLauncher.lnk''; $marker = ''$(ProjectDir)$(IntermediateOutputPath)service_was_registered.marker''; if (Test-Path $lnk) { New-Item -ItemType File -Path $marker -Force | Out-Null; Remove-Item $lnk -Force -ErrorAction SilentlyContinue; } Stop-Process -Name ''SMSSearch'',''SMSSearchLauncher'',''SMS Search Launcher'' -Force -ErrorAction SilentlyContinue'" />
+    <Exec Command="powershell.exe -ExecutionPolicy Bypass -NoProfile -NonInteractive -File &quot;$(MSBuildProjectDirectory)\PreBuildServiceCleanup.ps1&quot; -MarkerPath &quot;$(ProjectDir)$(IntermediateOutputPath)service_was_registered.marker&quot;" />
   </Target>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
@@ -80,7 +80,7 @@
   </Target>
 
   <Target Name="PostBuildServiceRestore" AfterTargets="Build" Condition="'$(OS)' == 'Windows_NT'">
-    <Exec Command="powershell.exe -ExecutionPolicy Bypass -NoProfile -NonInteractive -Command '$marker = ''$(ProjectDir)$(IntermediateOutputPath)service_was_registered.marker''; if (Test-Path $marker) { $startup = [System.Environment]::GetFolderPath([System.Environment+SpecialFolder]::Startup); $lnk = Join-Path $startup ''SMSSearchLauncher.lnk''; $WshShell = New-Object -comObject WScript.Shell; $Shortcut = $WshShell.CreateShortcut($lnk); $Shortcut.TargetPath = ''$(TargetPath)''; $Shortcut.Arguments = ''--listener''; $Shortcut.WorkingDirectory = ''$(TargetDir)''; $Shortcut.Save(); Start-Process -FilePath ''$(TargetPath)'' -ArgumentList ''--listener''; Remove-Item $marker -Force -ErrorAction SilentlyContinue; }'" />
+    <Exec Command="powershell.exe -ExecutionPolicy Bypass -NoProfile -NonInteractive -File &quot;$(MSBuildProjectDirectory)\PostBuildServiceRestore.ps1&quot; -MarkerPath &quot;$(ProjectDir)$(IntermediateOutputPath)service_was_registered.marker&quot; -TargetPath &quot;$(TargetPath)&quot; -TargetDir &quot;$([System.IO.Path]::GetDirectoryName('$(TargetPath)'))&quot;" />
   </Target>
 
 </Project>


### PR DESCRIPTION
Moved complex inline PowerShell commands from `.csproj` to external `.ps1` scripts to resolve `MSB3073` errors caused by `cmd.exe` command parsing (specifically pipe characters). Updated build targets to call these scripts with appropriate parameters.

---
*PR created automatically by Jules for task [12568667272824596](https://jules.google.com/task/12568667272824596) started by @Rapscallion0*