### PR TITLE
Fix build file lock (MSB3027) by running cleanup before Clean and waiting for process exit

### DIFF
--- a/PreBuildServiceCleanup.ps1
+++ b/PreBuildServiceCleanup.ps1
@@ -10,4 +10,11 @@ if (Test-Path $lnk) {
     Remove-Item $lnk -Force -ErrorAction SilentlyContinue
 }
 
-Stop-Process -Name 'SMSSearch','SMSSearchLauncher','SMS Search Launcher' -Force -ErrorAction SilentlyContinue
+$processNames = 'SMSSearch','SMSSearchLauncher','SMS Search Launcher'
+$processes = Get-Process -Name $processNames -ErrorAction SilentlyContinue
+
+if ($processes) {
+    $processes | Stop-Process -Force -ErrorAction SilentlyContinue
+    # Wait for the processes to actually exit to avoid file locks during build
+    $processes | Wait-Process -Timeout 10 -ErrorAction SilentlyContinue
+}

--- a/SMS Search.csproj
+++ b/SMS Search.csproj
@@ -13,8 +13,8 @@
     <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
   </PropertyGroup>
 
-  <Target Name="PreBuildServiceCleanup" BeforeTargets="Build" Condition="'$(OS)' == 'Windows_NT'">
-    <Exec Command="powershell.exe -ExecutionPolicy Bypass -NoProfile -NonInteractive -File &quot;$(MSBuildProjectDirectory)\PreBuildServiceCleanup.ps1&quot; -MarkerPath &quot;$(ProjectDir)$(IntermediateOutputPath)service_was_registered.marker&quot;" />
+  <Target Name="PreBuildServiceCleanup" BeforeTargets="Clean;Build" Condition="'$(OS)' == 'Windows_NT'">
+    <Exec Command="powershell.exe -ExecutionPolicy Bypass -NoProfile -NonInteractive -File &quot;$(MSBuildProjectDirectory)\PreBuildServiceCleanup.ps1&quot; -MarkerPath &quot;$(ProjectDir)service_was_registered.tmp&quot;" />
   </Target>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
@@ -80,7 +80,7 @@
   </Target>
 
   <Target Name="PostBuildServiceRestore" AfterTargets="Build" Condition="'$(OS)' == 'Windows_NT'">
-    <Exec Command="powershell.exe -ExecutionPolicy Bypass -NoProfile -NonInteractive -File &quot;$(MSBuildProjectDirectory)\PostBuildServiceRestore.ps1&quot; -MarkerPath &quot;$(ProjectDir)$(IntermediateOutputPath)service_was_registered.marker&quot; -TargetPath &quot;$(TargetPath)&quot; -TargetDir &quot;$([System.IO.Path]::GetDirectoryName('$(TargetPath)'))&quot;" />
+    <Exec Command="powershell.exe -ExecutionPolicy Bypass -NoProfile -NonInteractive -File &quot;$(MSBuildProjectDirectory)\PostBuildServiceRestore.ps1&quot; -MarkerPath &quot;$(ProjectDir)service_was_registered.tmp&quot; -TargetPath &quot;$(TargetPath)&quot; -TargetDir &quot;$([System.IO.Path]::GetDirectoryName('$(TargetPath)'))&quot;" />
   </Target>
 
 </Project>


### PR DESCRIPTION
This change addresses the build failure (MSB3027/MSB3021) caused by the `SMSSearch` service locking the executable during a "Rebuild" or "Clean". 

Previously, the cleanup target only ran before `Build`. During a `Rebuild`, the `Clean` target would run first, attempting to delete files while the service was still running, causing a failure. Additionally, `Clean` would delete the marker file in `obj/`, preventing the service from restarting automatically.

The fix moves the cleanup to run before `Clean`, moves the marker file to the project root (temporarily), and enforces a wait for the process to exit.

---
*PR created automatically by Jules for task [12056485472365174599](https://jules.google.com/task/12056485472365174599) started by @Rapscallion0*