### PR TITLE
Fix file locking during rebuild for "SMS Search" process

### DIFF
--- a/PreBuildServiceCleanup.ps1
+++ b/PreBuildServiceCleanup.ps1
@@ -10,7 +10,7 @@ if (Test-Path $lnk) {
     Remove-Item $lnk -Force -ErrorAction SilentlyContinue
 }
 
-$processNames = 'SMSSearch','SMSSearchLauncher','SMS Search Launcher'
+$processNames = 'SMSSearch','SMSSearchLauncher','SMS Search Launcher','SMS Search'
 $processes = Get-Process -Name $processNames -ErrorAction SilentlyContinue
 
 if ($processes) {


### PR DESCRIPTION
Updated `PreBuildServiceCleanup.ps1` to include `'SMS Search'` in the target process list, resolving file locking issues during rebuilds where the process name differs from the assembly name.

---
*PR created automatically by Jules for task [17271053294756631917](https://jules.google.com/task/17271053294756631917) started by @Rapscallion0*