### PR TITLE
Fix file locking issues on Rebuild by moving cleanup to InitialTargets

### DIFF
--- a/SMS Search.csproj
+++ b/SMS Search.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk" InitialTargets="PreBuildServiceCleanup">
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
@@ -13,7 +13,7 @@
     <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
   </PropertyGroup>
 
-  <Target Name="PreBuildServiceCleanup" BeforeTargets="Clean;Build" Condition="'$(OS)' == 'Windows_NT'">
+  <Target Name="PreBuildServiceCleanup" Condition="'$(OS)' == 'Windows_NT'">
     <Exec Command="powershell.exe -ExecutionPolicy Bypass -NoProfile -NonInteractive -File &quot;$(MSBuildProjectDirectory)\PreBuildServiceCleanup.ps1&quot; -MarkerPath &quot;$(ProjectDir)service_was_registered.tmp&quot;" />
   </Target>
 


### PR DESCRIPTION
Moved `PreBuildServiceCleanup` target to `InitialTargets` in `SMS Search.csproj` to resolve file locking issues during Rebuild. This ensures the process is stopped before the build system attempts to clean the output directory.

---
*PR created automatically by Jules for task [11029020956188924726](https://jules.google.com/task/11029020956188924726) started by @Rapscallion0*