### PR TITLE
Fix service stopping at end of build by scoping PreBuildServiceCleanup to Clean/Build targets

### DIFF
--- a/SMS Search.csproj
+++ b/SMS Search.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk" InitialTargets="PreBuildServiceCleanup">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
@@ -13,7 +13,7 @@
     <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
   </PropertyGroup>
 
-  <Target Name="PreBuildServiceCleanup" Condition="'$(OS)' == 'Windows_NT'">
+  <Target Name="PreBuildServiceCleanup" BeforeTargets="Clean;Build" Condition="'$(OS)' == 'Windows_NT'">
     <Exec Command="powershell.exe -ExecutionPolicy Bypass -NoProfile -NonInteractive -File &quot;$(MSBuildProjectDirectory)\PreBuildServiceCleanup.ps1&quot; -MarkerPath &quot;$(ProjectDir)service_was_registered.tmp&quot;" />
   </Target>
 


### PR DESCRIPTION
The `PreBuildServiceCleanup` target was previously configured as an `InitialTargets`. This meant it executed every time any target was invoked on the project. In Visual Studio, after a successful build (and subsequent service restore), the IDE often triggers secondary background builds (e.g., to resolve references or update IntelliSense). These secondary invocations would trigger `InitialTargets` again, causing `PreBuildServiceCleanup.ps1` to run and stop the service, but since it wasn't a full build, the `PostBuildServiceRestore` target wouldn't run, leaving the service stopped.

By moving the target to `BeforeTargets="Clean;Build"`, we ensure the cleanup script only runs when a `Clean` or `Build` is explicitly requested, which are the only times we need to unlock the executable files. This prevents the "double stop" behavior.

---
*PR created automatically by Jules for task [3106759639649212196](https://jules.google.com/task/3106759639649212196) started by @Rapscallion0*