### PR TITLE
⚡ Optimize DataGridView column resizing performance

### DIFF
--- a/frmMain.cs
+++ b/frmMain.cs
@@ -1447,6 +1447,10 @@ namespace SMS_Search
             }
 
             int rowsToCheck = Math.Min(dGrd.RowCount, rowLimit);
+            const int padding = 14; // Approximate padding for cell content
+
+            // Cache font to avoid property access overhead in loop
+            Font font = dGrd.DefaultCellStyle.Font ?? Font;
 
             foreach (DataGridViewColumn col in dGrd.Columns)
             {
@@ -1458,9 +1462,24 @@ namespace SMS_Search
                 // Measure Cells
                 for (int i = 0; i < rowsToCheck; i++)
                 {
-                    var cell = dGrd.Rows[i].Cells[col.Index];
-                    int cellWidth = cell.PreferredSize.Width;
-                    if (cellWidth > maxWidth) maxWidth = cellWidth;
+                    string valueStr = "";
+                    if (dGrd.VirtualMode)
+                    {
+                        var value = _gridContext.GetValue(i, col.Index);
+                        valueStr = value?.ToString() ?? "";
+                    }
+                    else
+                    {
+                        // Fallback for non-virtual mode
+                        var value = dGrd.Rows[i].Cells[col.Index].Value;
+                        valueStr = value?.ToString() ?? "";
+                    }
+
+                    if (!string.IsNullOrEmpty(valueStr))
+                    {
+                        int cellWidth = TextRenderer.MeasureText(valueStr, font).Width + padding;
+                        if (cellWidth > maxWidth) maxWidth = cellWidth;
+                    }
                 }
 
                 col.Width = maxWidth;


### PR DESCRIPTION
**Performance Optimization**:
*   Modified `ResizeColumnsBasedOnFirstRowsAsync` in `frmMain.cs` to use `TextRenderer.MeasureText` instead of `DataGridViewCell.PreferredSize`.
*   Directly retrieves values from `VirtualGridContext` (in Virtual Mode) or `dGrd.Rows[i].Cells[j].Value` (in Non-Virtual Mode) to calculate width.
*   Added a safe padding constant (14px) to account for standard cell padding and borders.
*   Cached `dGrd.DefaultCellStyle.Font` outside the loop.

**Why**:
The previous implementation iterated through 100 rows x N columns accessing `PreferredSize` for every cell. In Virtual Mode, accessing `Cells[index]` can trigger object instantiation and complex state checks, while `PreferredSize` performs expensive GDI+ measurements. The optimized approach measures the raw string directly using `TextRenderer`, which is significantly faster and sufficient for auto-sizing logic.

---
*PR created automatically by Jules for task [8096819622849507337](https://jules.google.com/task/8096819622849507337) started by @Rapscallion0*