### PR TITLE
Fix CS0017 multiple entry points by renaming BenchmarkSqlGen Main method

### DIFF
--- a/BenchmarkSqlGen.cs
+++ b/BenchmarkSqlGen.cs
@@ -10,7 +10,7 @@ public class BenchmarkSqlGen
         "char", "nchar", "varchar", "nvarchar", "text", "ntext"
     };
 
-    public static void Main(string[] args)
+    public static void Run(string[] args)
     {
         Console.WriteLine("Starting BenchmarkSqlGen...");
 


### PR DESCRIPTION
Renamed `Main` to `Run` in `BenchmarkSqlGen.cs` to resolve the `CS0017` multiple entry point compilation error. This ensures that `Program.cs` remains the sole entry point for the application while keeping the benchmark code compilable and available for manual execution.

---
*PR created automatically by Jules for task [12249935866207723833](https://jules.google.com/task/12249935866207723833) started by @Rapscallion0*