### PR TITLE
Maintain grid context focus when resizing columns

### DIFF
--- a/ExDataGridView.cs
+++ b/ExDataGridView.cs
@@ -6,6 +6,8 @@ namespace SMS_Search
     public class ExDataGridView : DataGridView
     {
         private const int WM_MOUSEHWHEEL = 0x020E;
+        private int _anchorColumnIndex = -1;
+        private int _anchorOffset = 0;
 
         protected override void WndProc(ref Message m)
         {
@@ -52,6 +54,89 @@ namespace SMS_Search
                 }
             }
             base.WndProc(ref m);
+        }
+
+        protected override void OnScroll(ScrollEventArgs e)
+        {
+            base.OnScroll(e);
+            UpdateAnchor();
+        }
+
+        private void UpdateAnchor()
+        {
+            if (this.Columns.Count == 0)
+            {
+                _anchorColumnIndex = -1;
+                _anchorOffset = 0;
+                return;
+            }
+
+            // FirstDisplayedScrollingColumnIndex corresponds to the first visible column in the SCROLLABLE area
+            int firstIdx = this.FirstDisplayedScrollingColumnIndex;
+            if (firstIdx >= 0 && firstIdx < this.Columns.Count)
+            {
+                _anchorColumnIndex = firstIdx;
+                int anchorDisplayIndex = this.Columns[firstIdx].DisplayIndex;
+
+                // Calculate offset into the column
+                // HorizontalScrollingOffset is total pixels scrolled in the scrollable area.
+                // We sum widths of visible, unfrozen columns that visually precede the anchor.
+
+                int sumWidths = 0;
+                foreach (DataGridViewColumn col in this.Columns)
+                {
+                    if (col.Visible && !col.Frozen && col.DisplayIndex < anchorDisplayIndex)
+                    {
+                        sumWidths += col.Width;
+                    }
+                }
+
+                _anchorOffset = this.HorizontalScrollingOffset - sumWidths;
+            }
+        }
+
+        protected override void OnColumnWidthChanged(DataGridViewColumnEventArgs e)
+        {
+            base.OnColumnWidthChanged(e);
+
+            if (this.Columns.Count == 0 || _anchorColumnIndex < 0) return;
+
+            // Check if anchor is still valid (bounds check)
+            if (_anchorColumnIndex >= this.Columns.Count)
+            {
+                _anchorColumnIndex = -1;
+                return;
+            }
+
+            // Only attempt to restore position if the anchor column is visible and not frozen
+            if (this.Columns[_anchorColumnIndex].Visible && !this.Columns[_anchorColumnIndex].Frozen)
+            {
+                int anchorDisplayIndex = this.Columns[_anchorColumnIndex].DisplayIndex;
+
+                int newSumWidths = 0;
+                foreach (DataGridViewColumn col in this.Columns)
+                {
+                    if (col.Visible && !col.Frozen && col.DisplayIndex < anchorDisplayIndex)
+                    {
+                        newSumWidths += col.Width;
+                    }
+                }
+
+                int newScrollOffset = newSumWidths + _anchorOffset;
+                if (newScrollOffset < 0) newScrollOffset = 0;
+
+                if (this.HorizontalScrollingOffset != newScrollOffset)
+                {
+                    try
+                    {
+                        this.HorizontalScrollingOffset = newScrollOffset;
+                    }
+                    catch
+                    {
+                        // Ignore range errors or transient states
+                    }
+                }
+            }
         }
     }
 }

--- a/frmMain.cs
+++ b/frmMain.cs
@@ -1414,8 +1414,6 @@ namespace SMS_Search
                 int limit = 5000;
                 if (string.IsNullOrEmpty(limitStr) || !int.TryParse(limitStr, out limit)) limit = 5000;
 
-                int firstDisplayedScrollingColumnIndex = dGrd.FirstDisplayedScrollingColumnIndex;
-
                 if (dGrd.RowCount <= limit)
                 {
                     if (dGrd.VirtualMode)
@@ -1428,11 +1426,6 @@ namespace SMS_Search
                 {
                     await ResizeColumnsBasedOnFirstRowsAsync(100);
                 }
-
-			    if (firstDisplayedScrollingColumnIndex >= 0)
-			    {
-				    dGrd.FirstDisplayedScrollingColumnIndex = firstDisplayedScrollingColumnIndex;
-			    }
 			}
 		}
 


### PR DESCRIPTION
Implemented logic in `ExDataGridView` to preserve the exact visual position of the first visible column when preceding columns are resized. This prevents the grid from jumping or shifting the user's view unexpectedly. Removed manual `FirstDisplayedScrollingColumnIndex` restoration in `frmMain.cs` to let the new logic take precedence. Correctly handled column reordering by using `DisplayIndex` in width calculations.

---
*PR created automatically by Jules for task [18260155814486712871](https://jules.google.com/task/18260155814486712871) started by @Rapscallion0*