### PR TITLE
Configurable Copy Delimiter

### DIFF
--- a/Settings/DisplaySettings.Designer.cs
+++ b/Settings/DisplaySettings.Designer.cs
@@ -36,6 +36,10 @@ namespace SMS_Search.Settings
             this.lblAutoResizeLimit = new System.Windows.Forms.Label();
             this.txtAutoResizeLimit = new System.Windows.Forms.TextBox();
             this.toolTip1 = new System.Windows.Forms.ToolTip(this.components);
+            this.lblCopyDelimiter = new System.Windows.Forms.Label();
+            this.cmbCopyDelimiter = new System.Windows.Forms.ComboBox();
+            this.txtCustomDelimiter = new System.Windows.Forms.TextBox();
+            this.lblCopyWarning = new System.Windows.Forms.Label();
             this.SuspendLayout();
             // 
             // lblDescription
@@ -99,12 +103,55 @@ namespace SMS_Search.Settings
             this.txtAutoResizeLimit.TabIndex = 5;
             this.toolTip1.SetToolTip(this.txtAutoResizeLimit, "Maximum number of rows to process when auto-resizing columns (improves performanc" +
         "e).");
+            //
+            // lblCopyDelimiter
+            //
+            this.lblCopyDelimiter.AutoSize = true;
+            this.lblCopyDelimiter.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.lblCopyDelimiter.Location = new System.Drawing.Point(15, 160);
+            this.lblCopyDelimiter.Name = "lblCopyDelimiter";
+            this.lblCopyDelimiter.Size = new System.Drawing.Size(91, 15);
+            this.lblCopyDelimiter.TabIndex = 6;
+            this.lblCopyDelimiter.Text = "Copy delimiter:";
+            //
+            // cmbCopyDelimiter
+            //
+            this.cmbCopyDelimiter.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.cmbCopyDelimiter.FormattingEnabled = true;
+            this.cmbCopyDelimiter.Location = new System.Drawing.Point(18, 180);
+            this.cmbCopyDelimiter.Name = "cmbCopyDelimiter";
+            this.cmbCopyDelimiter.Size = new System.Drawing.Size(150, 23);
+            this.cmbCopyDelimiter.TabIndex = 7;
+            this.toolTip1.SetToolTip(this.cmbCopyDelimiter, "Select delimiter for copy operations.");
+            //
+            // txtCustomDelimiter
+            //
+            this.txtCustomDelimiter.Location = new System.Drawing.Point(175, 180);
+            this.txtCustomDelimiter.Name = "txtCustomDelimiter";
+            this.txtCustomDelimiter.Size = new System.Drawing.Size(100, 23);
+            this.txtCustomDelimiter.TabIndex = 8;
+            this.toolTip1.SetToolTip(this.txtCustomDelimiter, "Enter custom delimiter characters.");
+            this.txtCustomDelimiter.Visible = false;
+            //
+            // lblCopyWarning
+            //
+            this.lblCopyWarning.AutoSize = true;
+            this.lblCopyWarning.ForeColor = System.Drawing.Color.DimGray;
+            this.lblCopyWarning.Location = new System.Drawing.Point(15, 210);
+            this.lblCopyWarning.Name = "lblCopyWarning";
+            this.lblCopyWarning.Size = new System.Drawing.Size(383, 15);
+            this.lblCopyWarning.TabIndex = 9;
+            this.lblCopyWarning.Text = "Note: Custom delimiters perform a text-only copy (Excel formatting may be lost).";
             // 
             // DisplaySettings
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.AutoScroll = true;
+            this.Controls.Add(this.lblCopyWarning);
+            this.Controls.Add(this.txtCustomDelimiter);
+            this.Controls.Add(this.cmbCopyDelimiter);
+            this.Controls.Add(this.lblCopyDelimiter);
             this.Controls.Add(this.txtAutoResizeLimit);
             this.Controls.Add(this.lblAutoResizeLimit);
             this.Controls.Add(this.chkShowRowNumbers);
@@ -128,5 +175,9 @@ namespace SMS_Search.Settings
         private System.Windows.Forms.Label lblAutoResizeLimit;
         private System.Windows.Forms.TextBox txtAutoResizeLimit;
         private System.Windows.Forms.ToolTip toolTip1;
+        private System.Windows.Forms.Label lblCopyDelimiter;
+        private System.Windows.Forms.ComboBox cmbCopyDelimiter;
+        private System.Windows.Forms.TextBox txtCustomDelimiter;
+        private System.Windows.Forms.Label lblCopyWarning;
     }
 }

--- a/Settings/DisplaySettings.cs
+++ b/Settings/DisplaySettings.cs
@@ -40,7 +40,37 @@ namespace SMS_Search.Settings
             if (string.IsNullOrEmpty(resizeLimit)) resizeLimit = "5000";
             txtAutoResizeLimit.Text = resizeLimit;
 
+            InitializeComboBox();
+            string delimiter = _config.GetValue("GENERAL", "COPY_DELIMITER");
+            if (string.IsNullOrEmpty(delimiter)) delimiter = "TAB";
+
+            if (cmbCopyDelimiter.Items.Contains(delimiter))
+                cmbCopyDelimiter.SelectedItem = delimiter;
+            else
+                cmbCopyDelimiter.SelectedIndex = 0;
+
+            txtCustomDelimiter.Text = _config.GetValue("GENERAL", "COPY_DELIMITER_CUSTOM");
+
+            UpdateDelimiterUI();
+
             _isLoaded = true;
+        }
+
+        private void InitializeComboBox()
+        {
+            cmbCopyDelimiter.Items.Clear();
+            cmbCopyDelimiter.Items.Add("TAB");
+            cmbCopyDelimiter.Items.Add("Comma (,)");
+            cmbCopyDelimiter.Items.Add("Pipe (|)");
+            cmbCopyDelimiter.Items.Add("Semicolon (;)");
+            cmbCopyDelimiter.Items.Add("Custom...");
+        }
+
+        private void UpdateDelimiterUI()
+        {
+            bool isCustom = cmbCopyDelimiter.Text == "Custom...";
+            txtCustomDelimiter.Visible = isCustom;
+            lblCopyWarning.Visible = cmbCopyDelimiter.Text != "TAB";
         }
 
         private void WireUpEvents()
@@ -63,6 +93,14 @@ namespace SMS_Search.Settings
                     txtAutoResizeLimit.Text = saved;
                 }
             };
+
+            cmbCopyDelimiter.SelectedIndexChanged += (s, e) =>
+            {
+                UpdateDelimiterUI();
+                SaveSetting("GENERAL", "COPY_DELIMITER", cmbCopyDelimiter.Text);
+            };
+
+            txtCustomDelimiter.TextChanged += (s, e) => SaveSetting("GENERAL", "COPY_DELIMITER_CUSTOM", txtCustomDelimiter.Text);
         }
 
         private void SaveSetting(string section, string key, string value)

--- a/Settings/frmConfig.Designer.cs
+++ b/Settings/frmConfig.Designer.cs
@@ -76,7 +76,7 @@ namespace SMS_Search.Settings
             treeNode2.ImageKey = "Display";
             treeNode2.Name = "Display";
             treeNode2.SelectedImageKey = "Display";
-            treeNode2.Text = "Display";
+            treeNode2.Text = "Result Grid";
             treeNode3.ImageKey = "Logging";
             treeNode3.Name = "Logging";
             treeNode3.SelectedImageKey = "Logging";


### PR DESCRIPTION
Implemented user request to allow configuring the delimiter used when copying data from the results grid. This includes:
1.  **UI Updates:**
    -   Added "Copy delimiter" ComboBox and "Custom" TextBox to `DisplaySettings`.
    -   Renamed "Display" node in the settings tree to "Result Grid".
    -   Renamed context menu items for clarity ("Copy selected").
2.  **Logic:**
    -   `frmMain` now checks the `COPY_DELIMITER` setting.
    -   If "TAB" (default), it uses the standard `DataGridView.GetClipboardContent()` method (preserving Excel compatibility).
    -   If a custom delimiter is chosen, it manually builds a string from the selected cells, joining them with the specified delimiter.
3.  **Persistence:**
    -   Settings are saved/loaded via `ConfigManager` keys `COPY_DELIMITER` and `COPY_DELIMITER_CUSTOM`.

---
*PR created automatically by Jules for task [8090934189531873039](https://jules.google.com/task/8090934189531873039) started by @Rapscallion0*