### PR TITLE
Fix async warnings in frmMain event handlers

### DIFF
--- a/frmMain.cs
+++ b/frmMain.cs
@@ -1571,9 +1571,9 @@ namespace SMS_Search
 			Application.Exit();
 		}
 
-		private void picRefresh_Click(object sender, EventArgs e)
+		private async void picRefresh_Click(object sender, EventArgs e)
 		{
-			PopulateTableList();
+			await PopulateTableList();
 		}
 
 		private void picRefresh_MouseEnter(object sender, EventArgs e)
@@ -1602,9 +1602,9 @@ namespace SMS_Search
 			getDbNames();
 		}
 
-		private void tscmbDbDatabase_SelectedIndexChanged(object sender, EventArgs e)
+		private async void tscmbDbDatabase_SelectedIndexChanged(object sender, EventArgs e)
 		{
-			PopulateTableList();
+			await PopulateTableList();
 		}
 
 		private async void getDbNames()


### PR DESCRIPTION
Addressed two CS4014 warnings in `frmMain.cs` where `PopulateTableList()` (an async Task) was called without await.
- Modified `picRefresh_Click` to be `async void` and await the call.
- Modified `tscmbDbDatabase_SelectedIndexChanged` to be `async void` and await the call.
- Verified build success (0 warnings) on Linux by temporarily adjusting project settings (then reverting them).

---
*PR created automatically by Jules for task [8005881267045110373](https://jules.google.com/task/8005881267045110373) started by @Rapscallion0*