### PR TITLE
Fix row header selection behavior in results grid

### DIFF
--- a/frmMain.cs
+++ b/frmMain.cs
@@ -1375,7 +1375,39 @@ namespace SMS_Search
             }
             else if (e.Button == MouseButtons.Left)
             {
-                dGrd.Rows[e.RowIndex].Selected = true;
+                if ((Control.ModifierKeys & Keys.Control) == Keys.Control)
+                {
+                    dGrd.Rows[e.RowIndex].Selected = !dGrd.Rows[e.RowIndex].Selected;
+                }
+                else if ((Control.ModifierKeys & Keys.Shift) == Keys.Shift)
+                {
+                    int startRow = dGrd.CurrentCell != null ? dGrd.CurrentCell.RowIndex : e.RowIndex;
+                    int endRow = e.RowIndex;
+                    int min = Math.Min(startRow, endRow);
+                    int max = Math.Max(startRow, endRow);
+
+                    dGrd.ClearSelection();
+
+                    for (int i = min; i <= max; i++)
+                    {
+                        dGrd.Rows[i].Selected = true;
+                    }
+                }
+                else
+                {
+                    dGrd.ClearSelection();
+                    dGrd.Rows[e.RowIndex].Selected = true;
+
+                    // Set CurrentCell to first visible column in this row
+                    foreach (DataGridViewColumn col in dGrd.Columns)
+                    {
+                        if (col.Visible)
+                        {
+                            dGrd.CurrentCell = dGrd[col.Index, e.RowIndex];
+                            break;
+                        }
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
This change fixes the issue where left-clicking a row header in the results grid would not select the row as expected. It implements standard DataGridView selection behavior (Exclusive, Multi-select with Ctrl, Range-select with Shift) manually within the `dGrd_RowHeaderMouseClick` event handler, as the default behavior was insufficient in `CellSelect` mode. It also ensures the `CurrentCell` is updated to the first visible column of the selected row to properly anchor focus.

---
*PR created automatically by Jules for task [16859224944339561603](https://jules.google.com/task/16859224944339561603) started by @Rapscallion0*