### PR TITLE
Fix DataGridView row selection and modifiers

### DIFF
--- a/frmMain.cs
+++ b/frmMain.cs
@@ -1373,42 +1373,6 @@ namespace SMS_Search
 
                 _rowHeaderMenu.Show(Cursor.Position);
             }
-            else if (e.Button == MouseButtons.Left)
-            {
-                if ((Control.ModifierKeys & Keys.Control) == Keys.Control)
-                {
-                    dGrd.Rows[e.RowIndex].Selected = !dGrd.Rows[e.RowIndex].Selected;
-                }
-                else if ((Control.ModifierKeys & Keys.Shift) == Keys.Shift)
-                {
-                    int startRow = dGrd.CurrentCell != null ? dGrd.CurrentCell.RowIndex : e.RowIndex;
-                    int endRow = e.RowIndex;
-                    int min = Math.Min(startRow, endRow);
-                    int max = Math.Max(startRow, endRow);
-
-                    dGrd.ClearSelection();
-
-                    for (int i = min; i <= max; i++)
-                    {
-                        dGrd.Rows[i].Selected = true;
-                    }
-                }
-                else
-                {
-                    dGrd.ClearSelection();
-                    dGrd.Rows[e.RowIndex].Selected = true;
-
-                    // Set CurrentCell to first visible column in this row
-                    foreach (DataGridViewColumn col in dGrd.Columns)
-                    {
-                        if (col.Visible)
-                        {
-                            dGrd.CurrentCell = dGrd[col.Index, e.RowIndex];
-                            break;
-                        }
-                    }
-                }
-            }
         }
 
         private void FilterBySelection_Click(object sender, EventArgs e)


### PR DESCRIPTION
Removed custom manual implementation of row selection in `dGrd_RowHeaderMouseClick` which was conflicting with standard `DataGridView` behavior. This custom logic prevented Ctrl/Shift modifiers from working correctly and caused inconsistencies between visual highlighting and actual cell selection state. The `DataGridView` is in `CellSelect` mode, which natively supports the desired behaviors (single row select, multi-select with modifiers, cell-only select) without manual intervention.

Key changes:
- Removed `else if (e.Button == MouseButtons.Left)` block in `frmMain.cs` within `dGrd_RowHeaderMouseClick`.
- Verified that `RowPrePaint` logic for active row highlighting (Cyan) does not interfere with standard selection highlighting (Blue).

---
*PR created automatically by Jules for task [7245088536462882434](https://jules.google.com/task/7245088536462882434) started by @Rapscallion0*