### PR TITLE
Fix row selection on header click in DataGridView

### DIFF
--- a/frmMain.cs
+++ b/frmMain.cs
@@ -1373,6 +1373,44 @@ namespace SMS_Search
 
                 _rowHeaderMenu.Show(Cursor.Position);
             }
+            else if (e.Button == MouseButtons.Left)
+            {
+                if (Control.ModifierKeys == Keys.Control)
+                {
+                    // Toggle selection
+                    dGrd.Rows[e.RowIndex].Selected = !dGrd.Rows[e.RowIndex].Selected;
+                }
+                else if (Control.ModifierKeys == Keys.Shift)
+                {
+                    // Range select
+                    int startRow = dGrd.CurrentCell != null ? dGrd.CurrentCell.RowIndex : e.RowIndex;
+                    int endRow = e.RowIndex;
+                    int min = Math.Min(startRow, endRow);
+                    int max = Math.Max(startRow, endRow);
+
+                    dGrd.ClearSelection();
+                    for (int i = min; i <= max; i++)
+                    {
+                        dGrd.Rows[i].Selected = true;
+                    }
+                }
+                else
+                {
+                    // Single select
+                    dGrd.ClearSelection();
+                    dGrd.Rows[e.RowIndex].Selected = true;
+                }
+
+                // Update current cell to the clicked row (first visible column) to anchor future Shift-clicks
+                if (dGrd.Columns.Count > 0)
+                {
+                    var firstVisCol = dGrd.Columns.GetFirstColumn(DataGridViewElementStates.Visible);
+                    if (firstVisCol != null)
+                    {
+                        dGrd.CurrentCell = dGrd[firstVisCol.Index, e.RowIndex];
+                    }
+                }
+            }
         }
 
         private void FilterBySelection_Click(object sender, EventArgs e)


### PR DESCRIPTION
This PR fixes an issue where clicking the row header in the results grid would "do nothing" instead of selecting the row as expected.

It implements manual selection logic within the `dGrd_RowHeaderMouseClick` event handler for the Left Mouse Button:
1.  **Standard Click:** Clears existing selection and selects the clicked row.
2.  **Ctrl + Click:** Toggles the selection state of the clicked row without clearing others.
3.  **Shift + Click:** Selects a range of rows from the current anchor (active cell) to the clicked row.

Additionally, it ensures that the `CurrentCell` is updated to the clicked row after a selection action. This is critical for setting the "anchor" for subsequent Shift-Click operations, providing a standard and intuitive user experience.

---
*PR created automatically by Jules for task [2957931402058782052](https://jules.google.com/task/2957931402058782052) started by @Rapscallion0*