### PR TITLE
Switch Grid SelectionMode to RowHeaderSelect

### DIFF
--- a/frmMain.Designer.cs
+++ b/frmMain.Designer.cs
@@ -259,7 +259,7 @@ namespace SMS_Search
             this.dGrd.Name = "dGrd";
             this.dGrd.ReadOnly = true;
             this.dGrd.RowHeadersVisible = false;
-            this.dGrd.SelectionMode = System.Windows.Forms.DataGridViewSelectionMode.CellSelect;
+            this.dGrd.SelectionMode = System.Windows.Forms.DataGridViewSelectionMode.RowHeaderSelect;
             this.dGrd.Size = new System.Drawing.Size(594, 301);
             this.dGrd.TabIndex = 4;
             this.dGrd.TabStop = false;

--- a/frmMain.cs
+++ b/frmMain.cs
@@ -1373,44 +1373,6 @@ namespace SMS_Search
 
                 _rowHeaderMenu.Show(Cursor.Position);
             }
-            else if (e.Button == MouseButtons.Left)
-            {
-                if (Control.ModifierKeys == Keys.Control)
-                {
-                    // Toggle selection
-                    dGrd.Rows[e.RowIndex].Selected = !dGrd.Rows[e.RowIndex].Selected;
-                }
-                else if (Control.ModifierKeys == Keys.Shift)
-                {
-                    // Range select
-                    int startRow = dGrd.CurrentCell != null ? dGrd.CurrentCell.RowIndex : e.RowIndex;
-                    int endRow = e.RowIndex;
-                    int min = Math.Min(startRow, endRow);
-                    int max = Math.Max(startRow, endRow);
-
-                    dGrd.ClearSelection();
-                    for (int i = min; i <= max; i++)
-                    {
-                        dGrd.Rows[i].Selected = true;
-                    }
-                }
-                else
-                {
-                    // Single select
-                    dGrd.ClearSelection();
-                    dGrd.Rows[e.RowIndex].Selected = true;
-                }
-
-                // Update current cell to the clicked row (first visible column) to anchor future Shift-clicks
-                if (dGrd.Columns.Count > 0)
-                {
-                    var firstVisCol = dGrd.Columns.GetFirstColumn(DataGridViewElementStates.Visible);
-                    if (firstVisCol != null)
-                    {
-                        dGrd.CurrentCell = dGrd[firstVisCol.Index, e.RowIndex];
-                    }
-                }
-            }
         }
 
         private void FilterBySelection_Click(object sender, EventArgs e)


### PR DESCRIPTION
Changed DataGridView.SelectionMode from CellSelect to RowHeaderSelect to natively support mixed cell and row selection with modifiers. Removed custom manual row selection logic.

---
*PR created automatically by Jules for task [4437432343548460304](https://jules.google.com/task/4437432343548460304) started by @Rapscallion0*