### PR TITLE
Fix row header context menu and hide editing icon

### DIFF
--- a/frmMain.cs
+++ b/frmMain.cs
@@ -89,6 +89,8 @@ namespace SMS_Search
             dGrd.CellPainting += dGrd_CellPainting;
             dGrd.CurrentCellChanged += dGrd_CurrentCellChanged;
             dGrd.RowHeaderMouseClick += dGrd_RowHeaderMouseClick;
+            dGrd.ShowEditingIcon = false;
+            dGrd.CellMouseClick += dGrd_CellMouseClick;
 
             _filterDebounceTimer = new System.Windows.Forms.Timer();
             _filterDebounceTimer.Interval = 500;
@@ -1299,8 +1301,6 @@ namespace SMS_Search
                 itemFilter.Enabled = canFilter;
             };
 
-            dGrd.ContextMenuStrip = _cellContextMenu;
-
 
             // 2. Column Header Context Menu
             _columnHeaderMenu = new ContextMenuStrip();
@@ -1372,6 +1372,14 @@ namespace SMS_Search
                 }
 
                 _rowHeaderMenu.Show(Cursor.Position);
+            }
+        }
+
+        private void dGrd_CellMouseClick(object sender, DataGridViewCellMouseEventArgs e)
+        {
+            if (e.Button == MouseButtons.Right && e.RowIndex >= 0 && e.ColumnIndex >= 0)
+            {
+                _cellContextMenu.Show(Cursor.Position);
             }
         }
 


### PR DESCRIPTION
This change restores the visibility of the "Copy as SQL INSERT" context menu item on the row headers by resolving a conflict where the cell context menu was taking precedence globally. It also disables the editing icon in the row header as requested. The cell context menu is now shown via a specific event handler that checks for cell clicks, allowing the row header click event to function correctly for its own menu.

---
*PR created automatically by Jules for task [2565983177532306143](https://jules.google.com/task/2565983177532306143) started by @Rapscallion0*