### PR TITLE
Enhance clipboard behavior for disjointed selections

### DIFF
--- a/frmClipboardOptions.Designer.cs
+++ b/frmClipboardOptions.Designer.cs
@@ -1,0 +1,117 @@
+using System;
+using System.Drawing;
+using System.Windows.Forms;
+
+namespace SMS_Search
+{
+    partial class frmClipboardOptions
+    {
+        private System.ComponentModel.IContainer components = null;
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        private void InitializeComponent()
+        {
+            this.lblMessage = new System.Windows.Forms.Label();
+            this.btnCopyContent = new System.Windows.Forms.Button();
+            this.btnPreserveLayout = new System.Windows.Forms.Button();
+            this.chkDontAsk = new System.Windows.Forms.CheckBox();
+            this.cmbScope = new System.Windows.Forms.ComboBox();
+            this.SuspendLayout();
+
+            //
+            // lblMessage
+            //
+            this.lblMessage.AutoSize = true;
+            this.lblMessage.Location = new System.Drawing.Point(12, 18);
+            this.lblMessage.Name = "lblMessage";
+            this.lblMessage.Size = new System.Drawing.Size(300, 30);
+            this.lblMessage.TabIndex = 0;
+            this.lblMessage.Text = "Your selection has gaps. How would you like to copy?\r\nChoose \"Content Only\" to ignore gaps or \"Preserve Layout\" to include them.";
+
+            //
+            // btnCopyContent
+            //
+            this.btnCopyContent.Location = new System.Drawing.Point(15, 60);
+            this.btnCopyContent.Name = "btnCopyContent";
+            this.btnCopyContent.Size = new System.Drawing.Size(120, 35);
+            this.btnCopyContent.TabIndex = 1;
+            this.btnCopyContent.Text = "Copy Content Only";
+            this.btnCopyContent.UseVisualStyleBackColor = true;
+            this.btnCopyContent.Click += new System.EventHandler(this.btnCopyContent_Click);
+
+            //
+            // btnPreserveLayout
+            //
+            this.btnPreserveLayout.Location = new System.Drawing.Point(197, 60);
+            this.btnPreserveLayout.Name = "btnPreserveLayout";
+            this.btnPreserveLayout.Size = new System.Drawing.Size(120, 35);
+            this.btnPreserveLayout.TabIndex = 2;
+            this.btnPreserveLayout.Text = "Preserve Layout";
+            this.btnPreserveLayout.UseVisualStyleBackColor = true;
+            this.btnPreserveLayout.Click += new System.EventHandler(this.btnPreserveLayout_Click);
+
+            //
+            // chkDontAsk
+            //
+            this.chkDontAsk.AutoSize = true;
+            this.chkDontAsk.Location = new System.Drawing.Point(15, 110);
+            this.chkDontAsk.Name = "chkDontAsk";
+            this.chkDontAsk.Size = new System.Drawing.Size(100, 17);
+            this.chkDontAsk.TabIndex = 3;
+            this.chkDontAsk.Text = "Don't ask again";
+            this.chkDontAsk.UseVisualStyleBackColor = true;
+            this.chkDontAsk.CheckedChanged += new System.EventHandler(this.chkDontAsk_CheckedChanged);
+
+            //
+            // cmbScope
+            //
+            this.cmbScope.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.cmbScope.FormattingEnabled = true;
+            this.cmbScope.Items.AddRange(new object[] {
+            "This Session",
+            "Forever"});
+            this.cmbScope.Location = new System.Drawing.Point(140, 108);
+            this.cmbScope.Name = "cmbScope";
+            this.cmbScope.Size = new System.Drawing.Size(100, 21);
+            this.cmbScope.TabIndex = 4;
+            this.cmbScope.SelectedIndexChanged += new System.EventHandler(this.cmbScope_SelectedIndexChanged);
+
+            //
+            // frmClipboardOptions
+            //
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(334, 151);
+            this.Controls.Add(this.cmbScope);
+            this.Controls.Add(this.chkDontAsk);
+            this.Controls.Add(this.btnPreserveLayout);
+            this.Controls.Add(this.btnCopyContent);
+            this.Controls.Add(this.lblMessage);
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
+            this.MaximizeBox = false;
+            this.MinimizeBox = false;
+            this.Name = "frmClipboardOptions";
+            this.ShowIcon = false;
+            this.ShowInTaskbar = false;
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
+            this.Text = "Disjointed Selection Detected";
+            this.ResumeLayout(false);
+            this.PerformLayout();
+
+        }
+
+        private System.Windows.Forms.Label lblMessage;
+        private System.Windows.Forms.Button btnCopyContent;
+        private System.Windows.Forms.Button btnPreserveLayout;
+        private System.Windows.Forms.CheckBox chkDontAsk;
+        private System.Windows.Forms.ComboBox cmbScope;
+    }
+}

--- a/frmClipboardOptions.cs
+++ b/frmClipboardOptions.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Drawing;
+using System.Windows.Forms;
+
+namespace SMS_Search
+{
+    public partial class frmClipboardOptions : Form
+    {
+        public enum CopyAction
+        {
+            Cancel,
+            CopyContent,
+            PreserveLayout
+        }
+
+        public enum MemoryScope
+        {
+            Session,
+            Forever
+        }
+
+        public CopyAction SelectedAction { get; private set; } = CopyAction.Cancel;
+        public bool RememberChoice { get; private set; } = false;
+        public MemoryScope RememberScope { get; private set; } = MemoryScope.Session;
+
+        public frmClipboardOptions()
+        {
+            InitializeComponent();
+            cmbScope.SelectedIndex = 0; // Default to Session
+            cmbScope.Enabled = false;
+        }
+
+        private void btnCopyContent_Click(object sender, EventArgs e)
+        {
+            SelectedAction = CopyAction.CopyContent;
+            Close();
+        }
+
+        private void btnPreserveLayout_Click(object sender, EventArgs e)
+        {
+            SelectedAction = CopyAction.PreserveLayout;
+            Close();
+        }
+
+        private void chkDontAsk_CheckedChanged(object sender, EventArgs e)
+        {
+            cmbScope.Enabled = chkDontAsk.Checked;
+            RememberChoice = chkDontAsk.Checked;
+        }
+
+        private void cmbScope_SelectedIndexChanged(object sender, EventArgs e)
+        {
+            if (cmbScope.SelectedIndex == 0)
+                RememberScope = MemoryScope.Session;
+            else
+                RememberScope = MemoryScope.Forever;
+        }
+    }
+}


### PR DESCRIPTION
This change enhances the clipboard functionality to better handle disjointed (non-contiguous) selections in the DataGridView. 

Key features:
1.  **Detection**: Automatically detects if a selection has gaps.
2.  **User Choice**: Prompts the user via a new dialog (`frmClipboardOptions`) to choose between "Copy Content Only" (ignore gaps) or "Preserve Layout" (include gaps/empty cells).
3.  **Persistence**: Allows users to save their preference for the session or permanently.
4.  **Async Operations**: Clipboard operations are performed asynchronously to prevent UI freezing.
5.  **Context Menu**: Adds an "Advance copy" submenu when a disjointed selection is active.
6.  **Ctrl+C Interception**: Overrides standard Ctrl+C behavior for the grid to support these new features.

Technical details:
- Added `frmClipboardOptions.cs` and `frmClipboardOptions.Designer.cs`.
- Modified `frmMain.cs` to include detection logic, async copy methods, and event handling.
- Integrated with existing `ConfigManager` and `Logfile` (Serilog).

---
*PR created automatically by Jules for task [18126393856818716827](https://jules.google.com/task/18126393856818716827) started by @Rapscallion0*