### PR TITLE
Automatically copy content for disjoint row selections

### DIFF
--- a/frmMain.cs
+++ b/frmMain.cs
@@ -1536,9 +1536,13 @@ namespace SMS_Search
 
             if (isDisjointed)
             {
-                // Check Session Preference
-                if (_clipboardSessionPreference.HasValue)
+                if (IsFullRowSelection())
                 {
+                    action = frmClipboardOptions.CopyAction.CopyContent;
+                }
+                else if (_clipboardSessionPreference.HasValue)
+                {
+                    // Check Session Preference
                     action = _clipboardSessionPreference.Value;
                 }
                 else
@@ -1638,6 +1642,27 @@ namespace SMS_Search
 
             long expectedCount = (long)(maxRow - minRow + 1) * (maxCol - minCol + 1);
             return dGrd.SelectedCells.Count != expectedCount;
+        }
+
+        private bool IsFullRowSelection()
+        {
+            if (dGrd.SelectedRows.Count == 0) return false;
+
+            var selectedRowIndices = new HashSet<int>();
+            foreach (DataGridViewRow row in dGrd.SelectedRows)
+            {
+                selectedRowIndices.Add(row.Index);
+            }
+
+            foreach (DataGridViewCell cell in dGrd.SelectedCells)
+            {
+                if (!selectedRowIndices.Contains(cell.RowIndex))
+                {
+                    return false;
+                }
+            }
+
+            return true;
         }
 
         private string GetDelimiter(string delimiterSetting)


### PR DESCRIPTION
Implemented automatic "Copy Content" behavior for disjoint full-row selections in `frmMain.cs`. This change introduces a helper method `IsFullRowSelection()` to detect when a user has selected multiple complete rows (potentially with gaps). In such cases, the `CopyToClipboard` method now defaults to copying the content only (skipping empty rows), bypassing the "Advanced Copy" dialog that is typically shown for disjoint selections. The dialog remains active for disjoint cell selections (partial rows) to allow users to choose between "Copy Content" and "Preserve Layout". This streamlines the workflow for row copying while maintaining flexibility for cell copying.

---
*PR created automatically by Jules for task [978073770504738684](https://jules.google.com/task/978073770504738684) started by @Rapscallion0*