### PR TITLE
Remove Advanced Copy from Row Header Context Menu

### DIFF
--- a/frmMain.cs
+++ b/frmMain.cs
@@ -1375,26 +1375,6 @@ namespace SMS_Search
             var itemRowCopyInsert = _rowHeaderMenu.Items.Add("Copy as SQL INSERT");
             itemRowCopyInsert.Click += (s, e) => CopyAsSqlInsert();
 
-            // Advance copy submenu (Row Header)
-            var itemRowAdvCopy = _rowHeaderMenu.Items.Add("Advance copy");
-            var itemRowAdvCopyContent = (itemRowAdvCopy as ToolStripMenuItem).DropDownItems.Add("Copy Content Only");
-            itemRowAdvCopyContent.Click += async (s, e) => {
-                 string del = config.GetValue("GENERAL", "COPY_DELIMITER");
-                 if (string.IsNullOrEmpty(del)) del = "TAB";
-                 await CopyContentOnlyAsync(false, del);
-            };
-            var itemRowAdvCopyLayout = (itemRowAdvCopy as ToolStripMenuItem).DropDownItems.Add("Preserve Layout");
-            itemRowAdvCopyLayout.Click += async (s, e) => {
-                 string del = config.GetValue("GENERAL", "COPY_DELIMITER");
-                 if (string.IsNullOrEmpty(del)) del = "TAB";
-                 await CopyPreserveLayoutAsync(false, del);
-            };
-
-            _rowHeaderMenu.Opening += (s, e) =>
-            {
-                itemRowAdvCopy.Visible = IsSelectionDisjointed();
-            };
-
             _rowHeaderMenu.Items.Add(new ToolStripSeparator());
 
             // Export selected rows to CSV


### PR DESCRIPTION
Removed "Advanced copy" from the Row Header context menu in `frmMain.cs` as requested. The option is still available in the Cell context menu. verified the changes by inspecting the code, confirming that the removal was clean and did not affect other functionalities like `CopyContentOnlyAsync` which are shared with the Cell context menu. Build was skipped due to platform limitations (Linux vs Windows Forms .NET 4.8), but static code analysis confirms syntax correctness.

---
*PR created automatically by Jules for task [15051380257131502435](https://jules.google.com/task/15051380257131502435) started by @Rapscallion0*