### PR TITLE
Fix CS1061 build error regarding Button.ToolTipText

### DIFF
--- a/frmMain.cs
+++ b/frmMain.cs
@@ -225,7 +225,7 @@ namespace SMS_Search
             btnHist.Location = new Point(anchorBtn.Left - 30, anchorBtn.Top);
             btnHist.Anchor = anchorBtn.Anchor;
             btnHist.Text = "H";
-            btnHist.ToolTipText = "Query History";
+            toolTip.SetToolTip(btnHist, "Query History");
             btnHist.Click += (s, e) => ShowHistoryMenu(s as Button, targetInput, type);
             btnHist.UseVisualStyleBackColor = true;
             anchorBtn.Parent.Controls.Add(btnHist);


### PR DESCRIPTION
Fixed a build error (CS1061) in `frmMain.cs` where the code was attempting to set a non-existent `ToolTipText` property on a `Button` control. Updated the code to use the existing `toolTip` component's `SetToolTip` method instead, which is the correct way to assign tooltips to standard Windows Forms controls.

---
*PR created automatically by Jules for task [15171823688448588474](https://jules.google.com/task/15171823688448588474) started by @Rapscallion0*