### PR TITLE
Replace MessageBox with Toast notifications for better UX

### DIFF
--- a/frmMain.cs
+++ b/frmMain.cs
@@ -836,7 +836,7 @@ namespace SMS_Search
 			    {
 				    tslblInfo.Text = "Connection failed!";
 				    tslblInfo.ForeColor = Color.Red;
-				    MessageBox.Show("Failed to connect to data source.\nPlease check your connection settings.", "SQL connection error", MessageBoxButtons.OK, MessageBoxIcon.Hand);
+                    Utils.showToast(2, "Failed to connect to data source.\nPlease check your connection settings.", "SQL connection error", Screen.FromControl(this));
 			    }
 			    setTabTextFocus();
                 if (!token.IsCancellationRequested)
@@ -886,14 +886,14 @@ namespace SMS_Search
             dGrd.Invalidate();
         }
 
-        private void _gridContext_LoadError(object sender, string e)
+        private void _gridContext_LoadError(object sender, string errorMessage)
         {
              if (this.InvokeRequired)
             {
-                this.Invoke(new Action(() => _gridContext_LoadError(sender, e)));
+                this.Invoke(new Action(() => _gridContext_LoadError(sender, errorMessage)));
                 return;
             }
-            MessageBox.Show(e, "Error loading data", MessageBoxButtons.OK, MessageBoxIcon.Error);
+            Utils.showToast(2, errorMessage, "Error loading data", Screen.FromControl(this));
         }
 
         private async void dGrd_ColumnHeaderMouseClick(object sender, DataGridViewCellMouseEventArgs e)
@@ -1289,7 +1289,7 @@ namespace SMS_Search
 			}
 			catch
 			{
-				MessageBox.Show("You must specify a valid Julian date (YYYYDDD).", "Julian date error", MessageBoxButtons.OK, MessageBoxIcon.Hand);
+                Utils.showToast(3, "You must specify a valid Julian date (YYYYDDD).", "Julian date error", Screen.FromControl(this));
 			}
 		}
         #endregion
@@ -1740,7 +1740,7 @@ namespace SMS_Search
             catch (Exception ex)
             {
                 log.Logger(LogLevel.Error, "Clipboard Error: " + ex.Message);
-                MessageBox.Show("Error copying to clipboard: " + ex.Message, "Copy Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                Utils.showToast(2, "Error copying to clipboard: " + ex.Message, "Copy Error", Screen.FromControl(this));
             }
         }
 
@@ -2173,7 +2173,7 @@ namespace SMS_Search
             catch (Exception ex)
             {
                  log.Logger(LogLevel.Error, "getDbNames error: " + ex.Message);
-                 MessageBox.Show("Failed to connect to data source. \n\nSQL error:\n" + ex.Message, "SQL connection error", MessageBoxButtons.OK, MessageBoxIcon.Hand);
+                 Utils.showToast(2, "Failed to connect to data source. \n\nSQL error:\n" + ex.Message, "SQL connection error", Screen.FromControl(this));
             }
             finally
             {
@@ -2729,7 +2729,7 @@ namespace SMS_Search
                     }
                     catch (Exception ex)
                     {
-                        MessageBox.Show("Error exporting: " + ex.Message, "Export Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                        Utils.showToast(2, "Error exporting: " + ex.Message, "Export Error", Screen.FromControl(this));
                     }
                     finally
                     {
@@ -2790,7 +2790,7 @@ namespace SMS_Search
                     }
                     catch (Exception ex)
                     {
-                        MessageBox.Show("Error exporting: " + ex.Message, "Export Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                        Utils.showToast(2, "Error exporting: " + ex.Message, "Export Error", Screen.FromControl(this));
                     }
                     finally
                     {
@@ -2860,7 +2860,7 @@ namespace SMS_Search
                     }
                     catch (Exception ex)
                     {
-                        MessageBox.Show("Error exporting: " + ex.Message, "Export Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                        Utils.showToast(2, "Error exporting: " + ex.Message, "Export Error", Screen.FromControl(this));
                     }
                     finally
                     {

--- a/frmToast.cs
+++ b/frmToast.cs
@@ -54,6 +54,26 @@ namespace SMS_Search
 
                     break;
             }
+
+            if (!string.IsNullOrEmpty(title) && title != "Message")
+            {
+                lblToastType.Text = title;
+            }
+
+            // Adjust height based on content
+            int padding = 10;
+            int rightMargin = 10;
+            lblToastMessage.MaximumSize = new Size(this.Width - lblToastMessage.Left - rightMargin, 0);
+
+            // Use PerformLayout to ensure AutoSize calculates the new height
+            this.PerformLayout();
+
+            int requiredHeight = lblToastMessage.Bottom + padding;
+            if (requiredHeight > 60)
+            {
+                this.Height = requiredHeight;
+                pnlToastBorder.Height = this.Height;
+            }
         }
 
         protected override bool ShowWithoutActivation


### PR DESCRIPTION
This change modernizes the application's feedback mechanism by replacing disruptive modal `MessageBox` popups with non-intrusive toast notifications for common errors and validation messages. This improves the user experience by not interrupting workflow for non-critical issues. Additionally, `frmToast` was improved to handle multi-line messages and custom titles, making it suitable for displaying detailed error information.

---
*PR created automatically by Jules for task [7599402077632856781](https://jules.google.com/task/7599402077632856781) started by @Rapscallion0*