### PR TITLE
Fix Utils namespace collision and missing references

### DIFF
--- a/Forms/frmMain.cs
+++ b/Forms/frmMain.cs
@@ -261,7 +261,7 @@ namespace SMS_Search.Forms
             clearItem.Click += (s, e) =>
             {
                 QueryHistoryManager.Instance.ClearHistory(type);
-                Utils.showToast(0, "History cleared", "History", Screen.FromControl(this));
+                GeneralUtils.showToast(0, "History cleared", "History", Screen.FromControl(this));
             };
 
             menu.Show(btn, new Point(0, btn.Height));
@@ -405,7 +405,7 @@ namespace SMS_Search.Forms
             {
                 if (!string.IsNullOrEmpty(lastRunVersion))
                 {
-                    Utils.showToast(0, "Updated from v" + lastRunVersion + " to v" + currentVersion, "Update", Screen.FromControl(this));
+                    GeneralUtils.showToast(0, "Updated from v" + lastRunVersion + " to v" + currentVersion, "Update", Screen.FromControl(this));
                 }
                 config.SetValue("GENERAL", "LAST_RUN_VERSION", currentVersion);
                 config.Save();
@@ -452,7 +452,7 @@ namespace SMS_Search.Forms
             else
             {
                 string user = config.GetValue("CONNECTION", "SQLUSER");
-                string pass = Utils.Decrypt(config.GetValue("CONNECTION", "SQLPASSWORD"));
+                string pass = GeneralUtils.Decrypt(config.GetValue("CONNECTION", "SQLPASSWORD"));
                 return "Data Source=" + DbServer + ";Initial Catalog=" + DbDatabase + ";User ID=" + user + ";Password=" + pass + ";Persist Security Info=False;";
             }
 		}
@@ -472,7 +472,7 @@ namespace SMS_Search.Forms
             {
                 bool useWinAuth = config.GetValue("CONNECTION", "WINDOWSAUTH") == "1" || string.IsNullOrEmpty(config.GetValue("CONNECTION", "WINDOWSAUTH"));
                 string user = useWinAuth ? null : config.GetValue("CONNECTION", "SQLUSER");
-                string pass = useWinAuth ? null : Utils.Decrypt(config.GetValue("CONNECTION", "SQLPASSWORD"));
+                string pass = useWinAuth ? null : GeneralUtils.Decrypt(config.GetValue("CONNECTION", "SQLPASSWORD"));
 
                 var tables = await _repo.GetTablesAsync(server, database, user, pass);
 
@@ -608,7 +608,7 @@ namespace SMS_Search.Forms
                 string database = config.GetValue("CONNECTION", "DATABASE");
                 bool useWinAuth = config.GetValue("CONNECTION", "WINDOWSAUTH") == "1" || string.IsNullOrEmpty(config.GetValue("CONNECTION", "WINDOWSAUTH"));
                 string user = useWinAuth ? null : config.GetValue("CONNECTION", "SQLUSER");
-                string pass = useWinAuth ? null : Utils.Decrypt(config.GetValue("CONNECTION", "SQLPASSWORD"));
+                string pass = useWinAuth ? null : GeneralUtils.Decrypt(config.GetValue("CONNECTION", "SQLPASSWORD"));
 
                 // Attempt to connect
                 connected = await dbConn.TestDbConnAsync(server, database, false, user, pass);
@@ -716,7 +716,7 @@ namespace SMS_Search.Forms
 
             bool useWinAuth = config.GetValue("CONNECTION", "WINDOWSAUTH") == "1" || string.IsNullOrEmpty(config.GetValue("CONNECTION", "WINDOWSAUTH"));
             string user = useWinAuth ? null : config.GetValue("CONNECTION", "SQLUSER");
-            string pass = useWinAuth ? null : Utils.Decrypt(config.GetValue("CONNECTION", "SQLPASSWORD"));
+            string pass = useWinAuth ? null : GeneralUtils.Decrypt(config.GetValue("CONNECTION", "SQLPASSWORD"));
 
             _gridContext.SetConnection(server, database, user, pass);
 
@@ -838,7 +838,7 @@ namespace SMS_Search.Forms
 			    {
 				    tslblInfo.Text = "Connection failed!";
 				    tslblInfo.ForeColor = Color.Red;
-                    Utils.showToast(2, "Failed to connect to data source.\nPlease check your connection settings.", "SQL connection error", Screen.FromControl(this));
+                    GeneralUtils.showToast(2, "Failed to connect to data source.\nPlease check your connection settings.", "SQL connection error", Screen.FromControl(this));
 			    }
 			    setTabTextFocus();
                 if (!token.IsCancellationRequested)
@@ -895,7 +895,7 @@ namespace SMS_Search.Forms
                 this.Invoke(new Action(() => _gridContext_LoadError(sender, errorMessage)));
                 return;
             }
-            Utils.showToast(2, errorMessage, "Error loading data", Screen.FromControl(this));
+            GeneralUtils.showToast(2, errorMessage, "Error loading data", Screen.FromControl(this));
         }
 
         private async void dGrd_ColumnHeaderMouseClick(object sender, DataGridViewCellMouseEventArgs e)
@@ -1291,7 +1291,7 @@ namespace SMS_Search.Forms
 			}
 			catch
 			{
-                Utils.showToast(3, "You must specify a valid Julian date (YYYYDDD).", "Julian date error", Screen.FromControl(this));
+                GeneralUtils.showToast(3, "You must specify a valid Julian date (YYYYDDD).", "Julian date error", Screen.FromControl(this));
 			}
 		}
         #endregion
@@ -1619,7 +1619,7 @@ namespace SMS_Search.Forms
             if (sb.Length > 0)
             {
                 Clipboard.SetText(sb.ToString());
-                Utils.showToast(0, "INSERT statements copied", "Copy", Screen.FromControl(this));
+                GeneralUtils.showToast(0, "INSERT statements copied", "Copy", Screen.FromControl(this));
             }
         }
 
@@ -1742,7 +1742,7 @@ namespace SMS_Search.Forms
             catch (Exception ex)
             {
                 log.Logger(LogLevel.Error, "Clipboard Error: " + ex.Message);
-                Utils.showToast(2, "Error copying to clipboard: " + ex.Message, "Copy Error", Screen.FromControl(this));
+                GeneralUtils.showToast(2, "Error copying to clipboard: " + ex.Message, "Copy Error", Screen.FromControl(this));
             }
         }
 
@@ -1953,7 +1953,7 @@ namespace SMS_Search.Forms
             string database = tscmbDbDatabase.Text;
             bool useWinAuth = config.GetValue("CONNECTION", "WINDOWSAUTH") == "1" || string.IsNullOrEmpty(config.GetValue("CONNECTION", "WINDOWSAUTH"));
             string user = useWinAuth ? null : config.GetValue("CONNECTION", "SQLUSER");
-            string pass = useWinAuth ? null : Utils.Decrypt(config.GetValue("CONNECTION", "SQLPASSWORD"));
+            string pass = useWinAuth ? null : GeneralUtils.Decrypt(config.GetValue("CONNECTION", "SQLPASSWORD"));
 
             try
             {
@@ -2166,7 +2166,7 @@ namespace SMS_Search.Forms
             {
                 bool useWinAuth = config.GetValue("CONNECTION", "WINDOWSAUTH") == "1" || string.IsNullOrEmpty(config.GetValue("CONNECTION", "WINDOWSAUTH"));
                 string user = useWinAuth ? null : config.GetValue("CONNECTION", "SQLUSER");
-                string pass = useWinAuth ? null : Utils.Decrypt(config.GetValue("CONNECTION", "SQLPASSWORD"));
+                string pass = useWinAuth ? null : GeneralUtils.Decrypt(config.GetValue("CONNECTION", "SQLPASSWORD"));
 
                 var dbs = await _repo.GetDatabasesAsync(server, user, pass);
                 tscmbDbDatabase.Items.AddRange(dbs.ToArray());
@@ -2175,7 +2175,7 @@ namespace SMS_Search.Forms
             catch (Exception ex)
             {
                  log.Logger(LogLevel.Error, "getDbNames error: " + ex.Message);
-                 Utils.showToast(2, "Failed to connect to data source. \n\nSQL error:\n" + ex.Message, "SQL connection error", Screen.FromControl(this));
+                 GeneralUtils.showToast(2, "Failed to connect to data source. \n\nSQL error:\n" + ex.Message, "SQL connection error", Screen.FromControl(this));
             }
             finally
             {
@@ -2721,7 +2721,7 @@ namespace SMS_Search.Forms
                         sw.Stop();
 
                         tslblInfo.Text = $"Exported in {sw.ElapsedMilliseconds} ms";
-                        Utils.showToast(0, "Export successful", "Export", Screen.FromControl(this));
+                        GeneralUtils.showToast(0, "Export successful", "Export", Screen.FromControl(this));
                     }
                     catch (OperationCanceledException)
                     {
@@ -2731,7 +2731,7 @@ namespace SMS_Search.Forms
                     }
                     catch (Exception ex)
                     {
-                        Utils.showToast(2, "Error exporting: " + ex.Message, "Export Error", Screen.FromControl(this));
+                        GeneralUtils.showToast(2, "Error exporting: " + ex.Message, "Export Error", Screen.FromControl(this));
                     }
                     finally
                     {
@@ -2788,11 +2788,11 @@ namespace SMS_Search.Forms
                                 writer.WriteLine(string.Join(",", values));
                             }
                         }
-                        Utils.showToast(0, "Export successful", "Export", Screen.FromControl(this));
+                        GeneralUtils.showToast(0, "Export successful", "Export", Screen.FromControl(this));
                     }
                     catch (Exception ex)
                     {
-                        Utils.showToast(2, "Error exporting: " + ex.Message, "Export Error", Screen.FromControl(this));
+                        GeneralUtils.showToast(2, "Error exporting: " + ex.Message, "Export Error", Screen.FromControl(this));
                     }
                     finally
                     {
@@ -2858,11 +2858,11 @@ namespace SMS_Search.Forms
                                 writer.WriteLine(string.Join(",", rowValues));
                             }
                         }
-                        Utils.showToast(0, "Export successful", "Export", Screen.FromControl(this));
+                        GeneralUtils.showToast(0, "Export successful", "Export", Screen.FromControl(this));
                     }
                     catch (Exception ex)
                     {
-                        Utils.showToast(2, "Error exporting: " + ex.Message, "Export Error", Screen.FromControl(this));
+                        GeneralUtils.showToast(2, "Error exporting: " + ex.Message, "Export Error", Screen.FromControl(this));
                     }
                     finally
                     {

--- a/Forms/frmPassDecrypt.cs
+++ b/Forms/frmPassDecrypt.cs
@@ -25,7 +25,7 @@ namespace SMS_Search.Forms
 
             // To be enabled once Encryption is figured out
             /*
-            txtEncrypted.Text = Utils.Encrypt(txtDecrypted.Text);
+            txtEncrypted.Text = GeneralUtils.Encrypt(txtDecrypted.Text);
             
             if (txtEncrypted.Text != "")
             {
@@ -33,14 +33,14 @@ namespace SMS_Search.Forms
                 Clipboard.SetText(txtEncrypted.Text);
 
                 // Show toast message
-                Utils.showToast(1, "Encrypted string copied to clipboard.");
+                GeneralUtils.showToast(1, "Encrypted string copied to clipboard.");
             }*/
             txtDecrypted.Focus();
         }
 
         private void btnDecrypt_Click(object sender, EventArgs e)
         {
-            txtDecrypted.Text = Utils.Decrypt(txtEncrypted.Text);
+            txtDecrypted.Text = GeneralUtils.Decrypt(txtEncrypted.Text);
 
             if (txtDecrypted.Text != "")
             {
@@ -48,7 +48,7 @@ namespace SMS_Search.Forms
                 Clipboard.SetText(txtDecrypted.Text);
 
                 // Show toast message
-                Utils.showToast(1, "Decrypted string copied to clipboard.");
+                GeneralUtils.showToast(1, "Decrypted string copied to clipboard.");
             }
             txtEncrypted.Focus();
         }

--- a/Settings/DatabaseSettings.cs
+++ b/Settings/DatabaseSettings.cs
@@ -87,7 +87,7 @@ namespace SMS_Search.Settings
             }
 
             txtDbUser.Text = _config.GetValue("CONNECTION", "SQLUSER");
-            txtDbPassword.Text = Utils.Decrypt(_config.GetValue("CONNECTION", "SQLPASSWORD"));
+            txtDbPassword.Text = GeneralUtils.Decrypt(_config.GetValue("CONNECTION", "SQLPASSWORD"));
 
             _isLoaded = true;
         }
@@ -159,7 +159,7 @@ namespace SMS_Search.Settings
             {
                 _config.SetValue("CONNECTION", "WINDOWSAUTH", "0");
                 _config.SetValue("CONNECTION", "SQLUSER", txtDbUser.Text);
-                _config.SetValue("CONNECTION", "SQLPASSWORD", Utils.Encrypt(txtDbPassword.Text));
+                _config.SetValue("CONNECTION", "SQLPASSWORD", GeneralUtils.Encrypt(txtDbPassword.Text));
             }
             _config.Save();
             (this.ParentForm as frmConfig)?.FlashSaved();

--- a/Settings/frmConfig.cs
+++ b/Settings/frmConfig.cs
@@ -139,7 +139,7 @@ namespace SMS_Search.Settings
                 string database = config.GetValue("CONNECTION", "DATABASE");
                 bool useWinAuth = config.GetValue("CONNECTION", "WINDOWSAUTH") == "1" || string.IsNullOrEmpty(config.GetValue("CONNECTION", "WINDOWSAUTH"));
                 string user = useWinAuth ? null : config.GetValue("CONNECTION", "SQLUSER");
-                string pass = useWinAuth ? null : Utils.Decrypt(config.GetValue("CONNECTION", "SQLPASSWORD"));
+                string pass = useWinAuth ? null : GeneralUtils.Decrypt(config.GetValue("CONNECTION", "SQLPASSWORD"));
 
                 dbConnector db = new dbConnector();
                 if (db.TestDbConn(server, database, false, user, pass))
@@ -226,7 +226,7 @@ namespace SMS_Search.Settings
                     tvSettings_AfterSelect(this, new TreeViewEventArgs(tvSettings.SelectedNode));
 
                  log.Logger(LogLevel.Info, "Settings reverted to default");
-                 Utils.showToast(0, "Settings reverted to default", "Settings", Screen.FromControl(this));
+                 GeneralUtils.showToast(0, "Settings reverted to default", "Settings", Screen.FromControl(this));
              }
         }
 

--- a/Utils/GeneralUtils.cs
+++ b/Utils/GeneralUtils.cs
@@ -2,10 +2,11 @@ using System;
 using System.Text;
 using System.Security.Cryptography;
 using System.Windows.Forms;
+using SMS_Search.Forms;
 
 namespace SMS_Search.Utils
 {
-    public class Utils
+    public class GeneralUtils
     {
         /// <summary>
         /// Display a toast message


### PR DESCRIPTION
Resolved compilation errors caused by a naming collision between the namespace `SMS_Search.Utils` and the class `SMS_Search.Utils.Utils`. Renamed the class to `GeneralUtils` and updated all call sites. Also fixed a missing reference to `SMS_Search.Forms` in `GeneralUtils.cs`.

---
*PR created automatically by Jules for task [15644345184888504584](https://jules.google.com/task/15644345184888504584) started by @Rapscallion0*