### PR TITLE
WPF MVVM Rewrite (.NET 10)

### DIFF
--- a/SMS_Search_WPF/SMSSearch.sln
+++ b/SMS_Search_WPF/SMSSearch.sln
@@ -1,0 +1,34 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SMSSearch", "SMSSearch\SMSSearch.csproj", "{54F1A29E-F70C-402D-81DD-E3115E38E214}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{54F1A29E-F70C-402D-81DD-E3115E38E214}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{54F1A29E-F70C-402D-81DD-E3115E38E214}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{54F1A29E-F70C-402D-81DD-E3115E38E214}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{54F1A29E-F70C-402D-81DD-E3115E38E214}.Debug|x64.Build.0 = Debug|Any CPU
+		{54F1A29E-F70C-402D-81DD-E3115E38E214}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{54F1A29E-F70C-402D-81DD-E3115E38E214}.Debug|x86.Build.0 = Debug|Any CPU
+		{54F1A29E-F70C-402D-81DD-E3115E38E214}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{54F1A29E-F70C-402D-81DD-E3115E38E214}.Release|Any CPU.Build.0 = Release|Any CPU
+		{54F1A29E-F70C-402D-81DD-E3115E38E214}.Release|x64.ActiveCfg = Release|Any CPU
+		{54F1A29E-F70C-402D-81DD-E3115E38E214}.Release|x64.Build.0 = Release|Any CPU
+		{54F1A29E-F70C-402D-81DD-E3115E38E214}.Release|x86.ActiveCfg = Release|Any CPU
+		{54F1A29E-F70C-402D-81DD-E3115E38E214}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/SMS_Search_WPF/SMSSearch/App.xaml
+++ b/SMS_Search_WPF/SMSSearch/App.xaml
@@ -1,0 +1,8 @@
+<Application x:Class="SMS_Search.App"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:local="clr-namespace:SMS_Search">
+    <Application.Resources>
+
+    </Application.Resources>
+</Application>

--- a/SMS_Search_WPF/SMSSearch/App.xaml.cs
+++ b/SMS_Search_WPF/SMSSearch/App.xaml.cs
@@ -1,0 +1,122 @@
+using Microsoft.Extensions.DependencyInjection;
+using SMS_Search.Data;
+using SMS_Search.Services;
+using SMS_Search.Utils;
+using SMS_Search.ViewModels;
+using SMS_Search.Views;
+using System;
+using System.IO;
+using System.Windows;
+using System.Windows.Input;
+using System.Windows.Interop;
+
+namespace SMS_Search
+{
+    public partial class App : Application
+    {
+        public new static App Current => (App)Application.Current;
+        public IServiceProvider Services { get; }
+
+        public App()
+        {
+            Services = ConfigureServices();
+        }
+
+        private static IServiceProvider ConfigureServices()
+        {
+            var services = new ServiceCollection();
+
+            services.AddSingleton<IConfigService>(provider =>
+                new ConfigManager(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "SMSSearch_settings.json")));
+
+            services.AddSingleton<ILoggerService>(provider => new LoggerService("App"));
+
+            services.AddSingleton<IDataRepository, DataRepository>();
+            services.AddTransient<VirtualGridContext>();
+            services.AddSingleton<IQueryHistoryService, QueryHistoryService>();
+
+            services.AddSingleton<IDialogService, DialogService>();
+            services.AddSingleton<IClipboardService, ClipboardService>();
+            services.AddSingleton<IHotkeyService, HotkeyService>();
+
+            services.AddTransient<MainViewModel>();
+            services.AddTransient<SearchViewModel>();
+            services.AddTransient<ResultsViewModel>();
+            services.AddTransient<SettingsViewModel>();
+
+            services.AddTransient<MainWindow>();
+            services.AddTransient<SettingsWindow>();
+
+            return services.BuildServiceProvider();
+        }
+
+        protected override void OnStartup(StartupEventArgs e)
+        {
+            base.OnStartup(e);
+
+            var logger = Services.GetRequiredService<ILoggerService>();
+            logger.LogInfo("Application starting...");
+
+            bool isListener = false;
+            foreach (var arg in e.Args)
+            {
+                if (arg == "--listener")
+                {
+                    isListener = true;
+                    break;
+                }
+            }
+
+            if (isListener)
+            {
+                var hiddenWindow = new Window
+                {
+                    Width = 0, Height = 0,
+                    WindowStyle = WindowStyle.None,
+                    ShowInTaskbar = false,
+                    Visibility = Visibility.Hidden
+                };
+                hiddenWindow.Show();
+                hiddenWindow.Hide();
+
+                var hotkeyService = Services.GetRequiredService<IHotkeyService>();
+                var config = Services.GetRequiredService<IConfigService>();
+
+                string hotkeyStr = config.GetValue("LAUNCHER", "HOTKEY");
+                if (!string.IsNullOrEmpty(hotkeyStr))
+                {
+                    try
+                    {
+                        var (key, modifiers) = HotkeyUtils.Parse(hotkeyStr);
+                        if (key != Key.None)
+                        {
+                            var helper = new WindowInteropHelper(hiddenWindow);
+                            hotkeyService.Register(helper.Handle, key, modifiers, () =>
+                            {
+                                try
+                                {
+                                    System.Diagnostics.Process.Start(System.Diagnostics.Process.GetCurrentProcess().MainModule.FileName);
+                                }
+                                catch (Exception ex)
+                                {
+                                    logger.LogError("Failed to launch application", ex);
+                                }
+                            });
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        logger.LogError("Error registering hotkey", ex);
+                    }
+                }
+
+                logger.LogInfo("Listener mode started.");
+            }
+            else
+            {
+                var mainWindow = Services.GetRequiredService<MainWindow>();
+                mainWindow.Show();
+            }
+        }
+    }
+}

--- a/SMS_Search_WPF/SMSSearch/AssemblyInfo.cs
+++ b/SMS_Search_WPF/SMSSearch/AssemblyInfo.cs
@@ -1,0 +1,10 @@
+using System.Windows;
+
+[assembly:ThemeInfo(
+    ResourceDictionaryLocation.None,            //where theme specific resource dictionaries are located
+                                                //(used if a resource is not found in the page,
+                                                // or application resource dictionaries)
+    ResourceDictionaryLocation.SourceAssembly   //where the generic resource dictionary is located
+                                                //(used if a resource is not found in the page,
+                                                // app, or any theme specific resource dictionaries)
+)]

--- a/SMS_Search_WPF/SMSSearch/Converters/BoolToVisibilityConverter.cs
+++ b/SMS_Search_WPF/SMSSearch/Converters/BoolToVisibilityConverter.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Globalization;
+using System.Windows;
+using System.Windows.Data;
+
+namespace SMS_Search.Converters
+{
+    public class BoolToVisibilityConverter : IValueConverter
+    {
+        public bool Invert { get; set; }
+
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            bool boolValue = value is bool b && b;
+            if (Invert) boolValue = !boolValue;
+            return boolValue ? Visibility.Visible : Visibility.Collapsed;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/SMS_Search_WPF/SMSSearch/Data/DataRepository.cs
+++ b/SMS_Search_WPF/SMSSearch/Data/DataRepository.cs
@@ -1,0 +1,400 @@
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Data.SqlClient;
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+using Dapper;
+using SMS_Search.Utils;
+
+namespace SMS_Search.Data
+{
+    public class DataRepository : IDataRepository
+    {
+        private readonly ILoggerService _logger;
+
+        public DataRepository(ILoggerService logger)
+        {
+            _logger = logger;
+        }
+
+        private static readonly HashSet<string> SafeStringTypes = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            "char", "nchar", "varchar", "nvarchar", "text", "ntext", "sysname"
+        };
+
+        public string GetConnectionString(string server, string database, string user, string pass)
+        {
+            if (string.IsNullOrEmpty(user))
+            {
+                return $"Integrated Security=SSPI;Persist Security Info=False;Initial Catalog={database};Data Source={server}";
+            }
+            else
+            {
+                return $"Data Source={server};Initial Catalog={database};User ID={user};Password={pass};Persist Security Info=False;";
+            }
+        }
+
+        public async Task<bool> TestConnectionAsync(string server, string database, string user, string pass, CancellationToken cancellationToken = default)
+        {
+            try
+            {
+                using (var conn = new SqlConnection(GetConnectionString(server, database, user, pass)))
+                {
+                    await conn.OpenAsync(cancellationToken);
+                    return true;
+                }
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        public bool TestConnection(string server, string database, string user, string pass)
+        {
+            try
+            {
+                using (var conn = new SqlConnection(GetConnectionString(server, database, user, pass)))
+                {
+                    conn.Open();
+                    return true;
+                }
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        public async Task<DataTable> ExecuteQueryAsync(string server, string database, string user, string pass, string sql, object parameters = null, CancellationToken cancellationToken = default)
+        {
+            using (var conn = new SqlConnection(GetConnectionString(server, database, user, pass)))
+            {
+                await conn.OpenAsync(cancellationToken);
+                var cmdDef = new CommandDefinition(sql, parameters, cancellationToken: cancellationToken);
+                using (var reader = await conn.ExecuteReaderAsync(cmdDef))
+                {
+                    var dt = new DataTable();
+                    dt.Load(reader);
+                    return dt;
+                }
+            }
+        }
+
+        public async Task<int> GetQueryCountAsync(string server, string database, string user, string pass, string sql, object parameters, string filter = null, CancellationToken cancellationToken = default)
+        {
+            string finalSql = ApplyFilter(sql, filter);
+            string countSql = $"SELECT COUNT(*) FROM ({finalSql}) AS _CountQ";
+
+            LogQuery("GetQueryCountAsync", countSql, parameters);
+
+            try
+            {
+                using (var conn = new SqlConnection(GetConnectionString(server, database, user, pass)))
+                {
+                    await conn.OpenAsync(cancellationToken);
+                    var cmdDef = new CommandDefinition(countSql, parameters, cancellationToken: cancellationToken);
+                    int count = await conn.ExecuteScalarAsync<int>(cmdDef);
+                    _logger.LogDebug($"GetQueryCountAsync: Returned {count}");
+                    return count;
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError($"GetQueryCountAsync: Error: {ex.Message}");
+                throw;
+            }
+        }
+
+        public async Task<DataTable> GetQueryPageAsync(string server, string database, string user, string pass, string sql, object parameters, int offset, int limit, string sortCol, string sortDir, string filter = null, CancellationToken cancellationToken = default)
+        {
+            string finalSql = ApplyFilter(sql, filter);
+
+            string orderBy = "(SELECT NULL)";
+            if (!string.IsNullOrEmpty(sortCol))
+            {
+                string safeCol = sortCol.Replace("[", "").Replace("]", "");
+                orderBy = $"[{safeCol}] {sortDir}";
+            }
+
+            string pageSql = $@"
+                SELECT * FROM ({finalSql}) AS _PageQ
+                ORDER BY {orderBy}
+                OFFSET {offset} ROWS FETCH NEXT {limit} ROWS ONLY";
+
+            using (var conn = new SqlConnection(GetConnectionString(server, database, user, pass)))
+            {
+                await conn.OpenAsync(cancellationToken);
+                var cmdDef = new CommandDefinition(pageSql, parameters, cancellationToken: cancellationToken);
+                using (var reader = await conn.ExecuteReaderAsync(cmdDef))
+                {
+                    var dt = new DataTable();
+                    dt.Load(reader);
+                    return dt;
+                }
+            }
+        }
+
+        public async Task<DataTable> GetQuerySchemaAsync(string server, string database, string user, string pass, string sql, object parameters, CancellationToken cancellationToken = default)
+        {
+            string schemaSql = $"SELECT TOP 0 * FROM ({sql}) AS _SchemaQ";
+
+            LogQuery("GetQuerySchemaAsync", schemaSql, parameters);
+
+            using (var conn = new SqlConnection(GetConnectionString(server, database, user, pass)))
+            {
+                await conn.OpenAsync(cancellationToken);
+                var cmdDef = new CommandDefinition(schemaSql, parameters, cancellationToken: cancellationToken);
+                using (var reader = await conn.ExecuteReaderAsync(cmdDef))
+                {
+                    var typeMap = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+                    for (int i = 0; i < reader.FieldCount; i++)
+                    {
+                        typeMap[reader.GetName(i)] = reader.GetDataTypeName(i);
+                    }
+
+                    var dt = new DataTable();
+                    dt.Load(reader);
+
+                    foreach (DataColumn col in dt.Columns)
+                    {
+                        if (typeMap.TryGetValue(col.ColumnName, out string sqlType))
+                        {
+                            col.ExtendedProperties["SqlType"] = sqlType;
+                        }
+                    }
+
+                    _logger.LogDebug($"GetQuerySchemaAsync: Returned {dt.Columns.Count} columns");
+                    return dt;
+                }
+            }
+        }
+
+        private void LogQuery(string method, string sql, object parameters)
+        {
+            string paramLog = "";
+            if (parameters is DynamicParameters dp)
+            {
+                var list = new List<string>();
+                foreach (var name in dp.ParameterNames)
+                {
+                    var val = dp.Get<object>(name);
+                    list.Add($"{name}={val}");
+                }
+                paramLog = string.Join(", ", list);
+            }
+            _logger.LogDebug($"{method}: Executing SQL: {sql} | Params: {paramLog}");
+        }
+
+        public async Task<DbDataReader> GetQueryDataReaderAsync(string server, string database, string user, string pass, string sql, object parameters, CancellationToken cancellationToken = default)
+        {
+            var conn = new SqlConnection(GetConnectionString(server, database, user, pass));
+            await conn.OpenAsync(cancellationToken);
+
+            using (var cmd = new SqlCommand(sql, conn))
+            {
+                if (parameters is DynamicParameters dp)
+                {
+                    foreach (var name in dp.ParameterNames)
+                    {
+                        var val = dp.Get<object>(name);
+                        cmd.Parameters.AddWithValue(name, val ?? DBNull.Value);
+                    }
+                }
+
+                return await cmd.ExecuteReaderAsync(CommandBehavior.CloseConnection, cancellationToken);
+            }
+        }
+
+        private string ApplyFilter(string sql, string filter)
+        {
+            if (string.IsNullOrWhiteSpace(filter)) return sql;
+            return $"SELECT * FROM ({sql}) AS _FilterQ WHERE {filter}";
+        }
+
+        public async Task<IEnumerable<string>> GetDatabasesAsync(string server, string user, string pass, CancellationToken cancellationToken = default)
+        {
+            using (var conn = new SqlConnection(GetConnectionString(server, "master", user, pass)))
+            {
+                await conn.OpenAsync(cancellationToken);
+                var cmdDef = new CommandDefinition("SELECT name FROM sys.databases ORDER BY name", cancellationToken: cancellationToken);
+                return await conn.QueryAsync<string>(cmdDef);
+            }
+        }
+
+        public async Task<IEnumerable<string>> GetTablesAsync(string server, string database, string user, string pass, CancellationToken cancellationToken = default)
+        {
+            using (var conn = new SqlConnection(GetConnectionString(server, database, user, pass)))
+            {
+                await conn.OpenAsync(cancellationToken);
+                var cmdDef = new CommandDefinition("SELECT NAME FROM sys.tables ORDER BY NAME", cancellationToken: cancellationToken);
+                return await conn.QueryAsync<string>(cmdDef);
+            }
+        }
+
+        public async Task<List<string>> GetColumnDescriptionsAsync(string server, string database, string user, string pass, IEnumerable<string> columnNames, CancellationToken cancellationToken = default)
+        {
+             using (var conn = new SqlConnection(GetConnectionString(server, database, user, pass)))
+             {
+                 await conn.OpenAsync(cancellationToken);
+                 string sql = "SELECT F1453 as Name, F1454 as Description FROM RB_FIELDS WHERE F1453 IN @Names";
+                 var cmdDef = new CommandDefinition(sql, new { Names = columnNames }, cancellationToken: cancellationToken);
+                 var result = await conn.QueryAsync(cmdDef);
+
+                 var dict = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+                 foreach(var r in result)
+                 {
+                     dict[r.Name.ToString()] = r.Description.ToString();
+                 }
+
+                 var list = new List<string>();
+                 foreach(var name in columnNames)
+                 {
+                     if (dict.TryGetValue(name, out string desc))
+                         list.Add(desc);
+                     else
+                         list.Add("");
+                 }
+                 return list;
+             }
+        }
+
+        public async Task<long> GetTotalMatchCountAsync(string server, string database, string user, string pass, string sql, object parameters, string filterClause, string filterText, Dictionary<string, string> columnTypes, CancellationToken cancellationToken = default)
+        {
+            if (string.IsNullOrWhiteSpace(filterText)) return 0;
+            string safeFilter = filterText.Replace("'", "''");
+
+            List<string> sumParts = new List<string>();
+            foreach (var kvp in columnTypes)
+            {
+                string col = kvp.Key;
+                string type = kvp.Value;
+                if (type != null && SafeStringTypes.Contains(type))
+                {
+                    sumParts.Add($"(CASE WHEN [{col}] LIKE '%{safeFilter}%' THEN 1 ELSE 0 END)");
+                }
+                else
+                {
+                    sumParts.Add($"(CASE WHEN CAST([{col}] AS NVARCHAR(MAX)) LIKE '%{safeFilter}%' THEN 1 ELSE 0 END)");
+                }
+            }
+            string sumExpression = string.Join(" + ", sumParts);
+
+            string finalSql = ApplyFilter(sql, filterClause);
+            string countSql = $"SELECT SUM((0 + {sumExpression})) FROM ({finalSql}) AS _CountQ";
+
+            using (var conn = new SqlConnection(GetConnectionString(server, database, user, pass)))
+            {
+                await conn.OpenAsync(cancellationToken);
+                var cmdDef = new CommandDefinition(countSql, parameters, cancellationToken: cancellationToken);
+                var result = await conn.ExecuteScalarAsync<object>(cmdDef);
+                if (result == null || result == DBNull.Value) return 0;
+                return Convert.ToInt64(result);
+            }
+        }
+
+        public async Task<long> GetPrecedingMatchCountAsync(string server, string database, string user, string pass, string sql, object parameters, string filterClause, string filterText, Dictionary<string, string> columnTypes, int limitRowIndex, string sortCol, string sortDir, CancellationToken cancellationToken = default)
+        {
+            if (limitRowIndex <= 0) return 0;
+            if (string.IsNullOrWhiteSpace(filterText)) return 0;
+            string safeFilter = filterText.Replace("'", "''");
+
+            List<string> sumParts = new List<string>();
+            foreach (var kvp in columnTypes)
+            {
+                string col = kvp.Key;
+                string type = kvp.Value;
+                if (type != null && SafeStringTypes.Contains(type))
+                {
+                    sumParts.Add($"(CASE WHEN [{col}] LIKE '%{safeFilter}%' THEN 1 ELSE 0 END)");
+                }
+                else
+                {
+                    sumParts.Add($"(CASE WHEN CAST([{col}] AS NVARCHAR(MAX)) LIKE '%{safeFilter}%' THEN 1 ELSE 0 END)");
+                }
+            }
+            string sumExpression = string.Join(" + ", sumParts);
+
+            string finalSql = ApplyFilter(sql, filterClause);
+
+            string orderBy = "(SELECT NULL)";
+            if (!string.IsNullOrEmpty(sortCol))
+            {
+                string safeCol = sortCol.Replace("[", "").Replace("]", "");
+                orderBy = $"[{safeCol}] {sortDir}";
+            }
+
+            string countSql = $@"
+                SELECT SUM((0 + {sumExpression}))
+                FROM (
+                    SELECT * FROM ({finalSql}) AS _Base
+                    ORDER BY {orderBy}
+                    OFFSET 0 ROWS FETCH NEXT {limitRowIndex} ROWS ONLY
+                ) AS _Preceding";
+
+            using (var conn = new SqlConnection(GetConnectionString(server, database, user, pass)))
+            {
+                await conn.OpenAsync(cancellationToken);
+                var cmdDef = new CommandDefinition(countSql, parameters, cancellationToken: cancellationToken);
+                var result = await conn.ExecuteScalarAsync<object>(cmdDef);
+                if (result == null || result == DBNull.Value) return 0;
+                return Convert.ToInt64(result);
+            }
+        }
+
+        public async Task<int> GetMatchRowIndexAsync(string server, string database, string user, string pass, string sql, object parameters, string filterClause, string searchText, Dictionary<string, string> columnTypes, int startRowIndex, string sortCol, string sortDir, bool forward, CancellationToken cancellationToken = default)
+        {
+            if (string.IsNullOrWhiteSpace(searchText)) return -1;
+            string safeFilter = searchText.Replace("'", "''");
+
+            List<string> searchParts = new List<string>();
+            foreach (var kvp in columnTypes)
+            {
+                string col = kvp.Key;
+                string type = kvp.Value;
+                if (type != null && SafeStringTypes.Contains(type))
+                {
+                    searchParts.Add($"[{col}] LIKE '%{safeFilter}%'");
+                }
+                else
+                {
+                    searchParts.Add($"CAST([{col}] AS NVARCHAR(MAX)) LIKE '%{safeFilter}%'");
+                }
+            }
+            string searchExpression = string.Join(" OR ", searchParts);
+
+            string finalSql = ApplyFilter(sql, filterClause);
+
+            string orderBy = "(SELECT NULL)";
+            if (!string.IsNullOrEmpty(sortCol))
+            {
+                string safeCol = sortCol.Replace("[", "").Replace("]", "");
+                orderBy = $"[{safeCol}] {sortDir}";
+            }
+
+            string comparison = forward ? ">" : "<";
+            string orderDirection = forward ? "ASC" : "DESC";
+
+            string query = $@"
+                SELECT TOP 1 RowNum
+                FROM (
+                    SELECT ROW_NUMBER() OVER (ORDER BY {orderBy}) - 1 as RowNum, *
+                    FROM ({finalSql}) AS _Base
+                ) AS _Ordered
+                WHERE RowNum {comparison} {startRowIndex}
+                AND ({searchExpression})
+                ORDER BY RowNum {orderDirection}";
+
+            using (var conn = new SqlConnection(GetConnectionString(server, database, user, pass)))
+            {
+                await conn.OpenAsync(cancellationToken);
+                var cmdDef = new CommandDefinition(query, parameters, cancellationToken: cancellationToken);
+                var result = await conn.ExecuteScalarAsync<object>(cmdDef);
+                if (result == null || result == DBNull.Value) return -1;
+                return Convert.ToInt32(result);
+            }
+        }
+    }
+}

--- a/SMS_Search_WPF/SMSSearch/Data/IDataRepository.cs
+++ b/SMS_Search_WPF/SMSSearch/Data/IDataRepository.cs
@@ -1,0 +1,26 @@
+using System.Collections.Generic;
+using System.Data;
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace SMS_Search.Data
+{
+    public interface IDataRepository
+    {
+        string GetConnectionString(string server, string database, string user, string pass);
+        Task<bool> TestConnectionAsync(string server, string database, string user, string pass, CancellationToken cancellationToken = default);
+        bool TestConnection(string server, string database, string user, string pass);
+        Task<DataTable> ExecuteQueryAsync(string server, string database, string user, string pass, string sql, object parameters = null, CancellationToken cancellationToken = default);
+        Task<int> GetQueryCountAsync(string server, string database, string user, string pass, string sql, object parameters, string filter = null, CancellationToken cancellationToken = default);
+        Task<DataTable> GetQueryPageAsync(string server, string database, string user, string pass, string sql, object parameters, int offset, int limit, string sortCol, string sortDir, string filter = null, CancellationToken cancellationToken = default);
+        Task<DataTable> GetQuerySchemaAsync(string server, string database, string user, string pass, string sql, object parameters, CancellationToken cancellationToken = default);
+        Task<DbDataReader> GetQueryDataReaderAsync(string server, string database, string user, string pass, string sql, object parameters, CancellationToken cancellationToken = default);
+        Task<IEnumerable<string>> GetDatabasesAsync(string server, string user, string pass, CancellationToken cancellationToken = default);
+        Task<IEnumerable<string>> GetTablesAsync(string server, string database, string user, string pass, CancellationToken cancellationToken = default);
+        Task<List<string>> GetColumnDescriptionsAsync(string server, string database, string user, string pass, IEnumerable<string> columnNames, CancellationToken cancellationToken = default);
+        Task<long> GetTotalMatchCountAsync(string server, string database, string user, string pass, string sql, object parameters, string filterClause, string filterText, Dictionary<string, string> columnTypes, CancellationToken cancellationToken = default);
+        Task<long> GetPrecedingMatchCountAsync(string server, string database, string user, string pass, string sql, object parameters, string filterClause, string filterText, Dictionary<string, string> columnTypes, int limitRowIndex, string sortCol, string sortDir, CancellationToken cancellationToken = default);
+        Task<int> GetMatchRowIndexAsync(string server, string database, string user, string pass, string sql, object parameters, string filterClause, string searchText, Dictionary<string, string> columnTypes, int startRowIndex, string sortCol, string sortDir, bool forward, CancellationToken cancellationToken = default);
+    }
+}

--- a/SMS_Search_WPF/SMSSearch/Data/Models.cs
+++ b/SMS_Search_WPF/SMSSearch/Data/Models.cs
@@ -1,0 +1,23 @@
+using Dapper;
+
+namespace SMS_Search.Data
+{
+    public enum SearchMode { Function, Totalizer, Field }
+    public enum SearchType { Number, Description, CustomSql, Table }
+
+    public class SearchCriteria
+    {
+        public SearchMode Mode { get; set; }
+        public SearchType Type { get; set; }
+        public string Value { get; set; }
+        public bool AnyMatch { get; set; }
+        public bool ShowFields { get; set; }
+        public bool LastTransaction { get; set; }
+    }
+
+    public class QueryResult
+    {
+        public string Sql { get; set; }
+        public DynamicParameters Parameters { get; set; }
+    }
+}

--- a/SMS_Search_WPF/SMSSearch/Data/QueryBuilder.cs
+++ b/SMS_Search_WPF/SMSSearch/Data/QueryBuilder.cs
@@ -1,0 +1,181 @@
+using Dapper;
+
+namespace SMS_Search.Data
+{
+    public class QueryBuilder
+    {
+        private readonly string _fctFields;
+        private readonly string _tlzFields;
+
+        // Base query for retrieving Field Metadata from system tables
+        private const string FieldSelectBase = @"SELECT
+    COL.name AS 'Field',
+    RBF.F1454 AS 'Description',
+    TAB.name AS 'Table',
+    REPLACE (RBF.F1458,'dt','') AS 'Type',
+    (CASE WHEN PKEY.COLUMN_NAME IS NOT NULL THEN '1' ELSE '0' END) AS 'Key',
+    COL.max_length AS 'Size',
+    COL.scale AS 'Dec',
+    (CASE WHEN COL.is_nullable = 0 THEN 1 ELSE 0 END) AS 'Required',
+    TAB.create_date AS 'Created'
+FROM sys.columns COL
+JOIN sys.tables TAB ON COL.object_id = TAB.object_id
+JOIN RB_FIELDS RBF ON COL.name = RBF.F1453 ";
+
+        private const string FieldSelectJoinPKey = @"
+LEFT OUTER JOIN INFORMATION_SCHEMA.KEY_COLUMN_USAGE PKEY ON
+    PKEY.COLUMN_NAME = COL.name AND
+    TAB.name=PKEY.TABLE_NAME";
+
+        private const string FieldSelectGroupBy = @"
+GROUP BY
+    COL.name,
+    RBF.F1454,
+    TAB.name,
+    RBF.F1458,
+    pkey.COLUMN_NAME,
+    COL.max_length,
+    COL.scale,
+    COL.is_nullable,
+    TAB.create_date";
+
+        public QueryBuilder(string fctFields, string tlzFields)
+        {
+            _fctFields = string.IsNullOrEmpty(fctFields) ? "F1063, F1064, F1051, F1050, F1081" : fctFields;
+            _tlzFields = string.IsNullOrEmpty(tlzFields) ? "F1034, F1039, F1128, F1129, F1179, F1253, F1710, F1131, F1048, F1709" : tlzFields;
+        }
+
+        public QueryResult Build(SearchCriteria criteria)
+        {
+            var p = new DynamicParameters();
+            string sql = "";
+
+            if (criteria.Mode == SearchMode.Field)
+            {
+                if (criteria.Type == SearchType.Number)
+                {
+                    string fldNum = "F" + criteria.Value;
+                    HandleWildcards(ref fldNum, out string op);
+
+                    sql = $"{FieldSelectBase} AND RBF.F1452 = TAB.name {FieldSelectJoinPKey} WHERE col.name {op} @Val {FieldSelectGroupBy}";
+                    p.Add("Val", fldNum);
+                }
+                else if (criteria.Type == SearchType.Description)
+                {
+                    string desc = criteria.Value;
+                    if (criteria.AnyMatch) desc = $"*{desc}*";
+                    HandleWildcards(ref desc, out string op);
+
+                    sql = $"{FieldSelectBase} AND RBF.F1452 = TAB.name {FieldSelectJoinPKey} WHERE RBF.F1454 {op} @Val {FieldSelectGroupBy}";
+                    p.Add("Val", desc);
+                }
+                else if (criteria.Type == SearchType.Table)
+                {
+                    if (criteria.ShowFields)
+                    {
+                        string table = criteria.Value;
+                        HandleWildcards(ref table, out string op);
+
+                        sql = $"{FieldSelectBase} AND RBF.F1452 {op} @Table {FieldSelectJoinPKey} WHERE TAB.name {op} @Table {FieldSelectGroupBy}";
+                        p.Add("Table", table);
+                    }
+                    else
+                    {
+                        string tableName = SanitizeIdentifier(criteria.Value);
+                        sql = $"SELECT * FROM {tableName}";
+
+                        if (criteria.LastTransaction)
+                        {
+                            sql += $" WHERE F1032 = (SELECT DISTINCT TOP 1 F1032 FROM {tableName} ORDER BY F1032 DESC)";
+                        }
+                    }
+                }
+                else if (criteria.Type == SearchType.CustomSql)
+                {
+                    sql = criteria.Value;
+                }
+            }
+            else if (criteria.Mode == SearchMode.Totalizer)
+            {
+                sql = $"Select {_tlzFields} FROM TLZ_TAB";
+                if (criteria.Type == SearchType.Number)
+                {
+                    if (!string.IsNullOrEmpty(criteria.Value))
+                    {
+                        string val = criteria.Value;
+                        HandleWildcards(ref val, out string op);
+                        sql += $" WHERE F1034 {op} @Val";
+                        p.Add("Val", val);
+                    }
+                }
+                else if (criteria.Type == SearchType.Description)
+                {
+                    if (!string.IsNullOrEmpty(criteria.Value))
+                    {
+                        string val = criteria.Value;
+                        if (criteria.AnyMatch) val = $"*{val}*";
+                        HandleWildcards(ref val, out string op);
+                        sql += $" WHERE F1039 {op} @Val";
+                        p.Add("Val", val);
+                    }
+                }
+                else if (criteria.Type == SearchType.CustomSql)
+                {
+                    sql = criteria.Value;
+                }
+            }
+            else if (criteria.Mode == SearchMode.Function)
+            {
+                sql = $"Select {_fctFields} FROM FCT_TAB";
+                if (criteria.Type == SearchType.Number)
+                {
+                    if (!string.IsNullOrEmpty(criteria.Value))
+                    {
+                        string val = criteria.Value;
+                        HandleWildcards(ref val, out string op);
+                        sql += $" WHERE F1063 {op} @Val";
+                        p.Add("Val", val);
+                    }
+                }
+                else if (criteria.Type == SearchType.Description)
+                {
+                    if (!string.IsNullOrEmpty(criteria.Value))
+                    {
+                        string val = criteria.Value;
+                        if (criteria.AnyMatch) val = $"*{val}*";
+                        HandleWildcards(ref val, out string op);
+                        sql += $" WHERE F1064 {op} @Val";
+                        p.Add("Val", val);
+                    }
+                }
+                else if (criteria.Type == SearchType.CustomSql)
+                {
+                    sql = criteria.Value;
+                }
+            }
+
+            if (string.IsNullOrEmpty(sql)) sql = "SELECT * FROM SYS_TAB";
+
+            return new QueryResult { Sql = sql, Parameters = p };
+        }
+
+        private void HandleWildcards(ref string value, out string op)
+        {
+            if (value.Contains("*") || value.Contains("?"))
+            {
+                value = value.Replace("*", "%").Replace("?", "_");
+                op = "LIKE";
+            }
+            else
+            {
+                op = "=";
+            }
+        }
+
+        private string SanitizeIdentifier(string id)
+        {
+            string clean = id.Replace("[", "").Replace("]", "");
+            return "[" + clean + "]";
+        }
+    }
+}

--- a/SMS_Search_WPF/SMSSearch/Data/QueryHistoryService.cs
+++ b/SMS_Search_WPF/SMSSearch/Data/QueryHistoryService.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using SMS_Search.Utils;
+
+namespace SMS_Search.Data
+{
+    public interface IQueryHistoryService
+    {
+        void AddQuery(string type, string sql);
+        List<string> GetHistory(string type);
+        void ClearHistory(string type);
+    }
+
+    public class QueryHistoryService : IQueryHistoryService
+    {
+        private readonly IConfigService _config;
+        private const int MaxHistory = 20;
+        private const string SectionName = "QUERY_HISTORY";
+
+        public QueryHistoryService(IConfigService config)
+        {
+            _config = config;
+        }
+
+        public void AddQuery(string type, string sql)
+        {
+            if (string.IsNullOrWhiteSpace(sql)) return;
+
+            var history = GetHistory(type);
+
+            history.RemoveAll(x => x.Equals(sql, StringComparison.OrdinalIgnoreCase));
+            history.Insert(0, sql);
+
+            if (history.Count > MaxHistory)
+            {
+                history = history.Take(MaxHistory).ToList();
+            }
+
+            SaveHistory(type, history);
+        }
+
+        public List<string> GetHistory(string type)
+        {
+            string json = _config.GetValue(SectionName, type);
+            if (string.IsNullOrEmpty(json)) return new List<string>();
+
+            try
+            {
+                return JsonSerializer.Deserialize<List<string>>(json) ?? new List<string>();
+            }
+            catch
+            {
+                return new List<string>();
+            }
+        }
+
+        public void ClearHistory(string type)
+        {
+            SaveHistory(type, new List<string>());
+        }
+
+        private void SaveHistory(string type, List<string> history)
+        {
+            try
+            {
+                string json = JsonSerializer.Serialize(history);
+                _config.SetValue(SectionName, type, json);
+                _config.Save();
+            }
+            catch { }
+        }
+    }
+}

--- a/SMS_Search_WPF/SMSSearch/Data/SqlCleaner.cs
+++ b/SMS_Search_WPF/SMSSearch/Data/SqlCleaner.cs
@@ -1,0 +1,67 @@
+using System.Collections.Generic;
+
+namespace SMS_Search.Data
+{
+    public struct SqlCleaningRule
+    {
+        public string Pattern;
+        public string Replacement;
+    }
+
+    public static class SqlCleaner
+    {
+        public static List<SqlCleaningRule> DefaultRules
+        {
+            get
+            {
+                return new List<SqlCleaningRule>
+                {
+                    new SqlCleaningRule { Pattern = "&amp;", Replacement = "&" },
+                    new SqlCleaningRule { Pattern = "<(/|)(((logsql|sql|prm|msg|errsql|logurl|).*?)|(pre|p|(br(( |)/|))))>", Replacement = "" },
+                    new SqlCleaningRule { Pattern = "&lt;", Replacement = "<" },
+                    new SqlCleaningRule { Pattern = "&gt;", Replacement = ">" },
+                    new SqlCleaningRule { Pattern = @"\[", Replacement = "(" },
+                    new SqlCleaningRule { Pattern = @"\]", Replacement = ")" },
+                    new SqlCleaningRule { Pattern = "&quot;", Replacement = "'" },
+                    new SqlCleaningRule { Pattern = @"\{09\}", Replacement = "" },
+
+                    new SqlCleaningRule { Pattern = @"\bselect\b", Replacement = "SELECT" },
+                    new SqlCleaningRule { Pattern = @"\s*\binsert\s+into\b", Replacement = "\r\nINSERT INTO" },
+                    new SqlCleaningRule { Pattern = @"\s*\bupdate\b", Replacement = "\r\nUPDATE" },
+                    new SqlCleaningRule { Pattern = @"\s*\bdelete\s+from\b", Replacement = "\r\nDELETE FROM" },
+
+                    new SqlCleaningRule { Pattern = @"(?<!\bdelete\s*)\s*\bfrom\b", Replacement = "\r\nFROM" },
+
+                    new SqlCleaningRule { Pattern = @"\s*\bwhere\b", Replacement = "\r\nWHERE" },
+                    new SqlCleaningRule { Pattern = @"\s*\bgroup\s+by\b", Replacement = "\r\nGROUP BY" },
+                    new SqlCleaningRule { Pattern = @"\s*\border\s+by\b", Replacement = "\r\nORDER BY" },
+                    new SqlCleaningRule { Pattern = @"\s*\bhaving\b", Replacement = "\r\nHAVING" },
+                    new SqlCleaningRule { Pattern = @"\s*\bdeclare\b", Replacement = "\r\nDECLARE" },
+
+                    new SqlCleaningRule { Pattern = @"\s*\bleft\s+outer\s+join\b", Replacement = "\r\n\tLEFT OUTER JOIN" },
+                    new SqlCleaningRule { Pattern = @"\s*\bright\s+outer\s+join\b", Replacement = "\r\n\tRIGHT OUTER JOIN" },
+                    new SqlCleaningRule { Pattern = @"\s*\bfull\s+outer\s+join\b", Replacement = "\r\n\tFULL OUTER JOIN" },
+                    new SqlCleaningRule { Pattern = @"\s*\bleft\s+join\b", Replacement = "\r\n\tLEFT JOIN" },
+                    new SqlCleaningRule { Pattern = @"\s*\bright\s+join\b", Replacement = "\r\n\tRIGHT JOIN" },
+                    new SqlCleaningRule { Pattern = @"\s*\binner\s+join\b", Replacement = "\r\n\tINNER JOIN" },
+
+                    new SqlCleaningRule { Pattern = @"(?<!\b(left|right|full)\s*)\s*\bouter\s+join\b", Replacement = "\r\n\tOUTER JOIN" },
+
+                    new SqlCleaningRule { Pattern = @"\s*\bcross\s+join\b", Replacement = "\r\n\tCROSS JOIN" },
+                    new SqlCleaningRule { Pattern = @"\s*\bfull\s+join\b", Replacement = "\r\n\tFULL JOIN" },
+
+                    new SqlCleaningRule { Pattern = @"(?<!\b(left|right|inner|outer|cross|full)\s*)\s*\bjoin\b", Replacement = "\r\n\tJOIN" },
+
+                    new SqlCleaningRule { Pattern = @"\s*\bwhen\b", Replacement = "\r\n\tWHEN" },
+
+                    new SqlCleaningRule { Pattern = @"\s*\bon\b", Replacement = "\r\n\t\tON" },
+
+                    new SqlCleaningRule { Pattern = @"\s*\bunion\b\s*", Replacement = "\r\nUNION\r\n" },
+
+                    new SqlCleaningRule { Pattern = @"\s*\band\b", Replacement = "\r\n\tAND" },
+                    new SqlCleaningRule { Pattern = @"\s*\bor\b", Replacement = "\r\n\tOR" }
+                };
+            }
+        }
+    }
+}

--- a/SMS_Search_WPF/SMSSearch/Data/VirtualGridContext.cs
+++ b/SMS_Search_WPF/SMSSearch/Data/VirtualGridContext.cs
@@ -1,0 +1,463 @@
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Text.Json;
+
+namespace SMS_Search.Data
+{
+    public class VirtualGridContext
+    {
+        private readonly IDataRepository _repo;
+
+        private string _server;
+        private string _database;
+        private string _user;
+        private string _pass;
+
+        private string _baseSql;
+        private object _parameters;
+
+        public int TotalCount { get; private set; }
+        public int UnfilteredCount { get; private set; }
+        private Dictionary<int, DataRow> _cache;
+        private HashSet<int> _pagesBeingFetched;
+        private Dictionary<int, TaskCompletionSource<bool>> _pageCompletionSources;
+        private const int PageSize = 100;
+        private int _version = 0;
+
+        public string SortColumn { get; private set; }
+        public string SortDirection { get; private set; } = "ASC";
+        public string FilterText { get; private set; }
+        private string _rawFilterText;
+        private List<string> _filterColumns;
+
+        private Dictionary<string, string> _columnSqlTypes = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+        private static readonly HashSet<string> SafeStringTypes = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            "char", "nchar", "varchar", "nvarchar", "text", "ntext", "sysname"
+        };
+
+        public event EventHandler DataReady;
+        public event EventHandler<string> LoadError;
+
+        public VirtualGridContext(IDataRepository repo)
+        {
+            _repo = repo;
+            _cache = new Dictionary<int, DataRow>();
+            _pagesBeingFetched = new HashSet<int>();
+            _pageCompletionSources = new Dictionary<int, TaskCompletionSource<bool>>();
+        }
+
+        public void SetConnection(string server, string database, string user, string pass)
+        {
+            _server = server;
+            _database = database;
+            _user = user;
+            _pass = pass;
+        }
+
+        public async Task LoadAsync(string sql, object parameters, string initialSortColumn = null, CancellationToken cancellationToken = default)
+        {
+            _baseSql = sql;
+            _parameters = parameters;
+            SortColumn = initialSortColumn;
+            SortDirection = "ASC";
+            FilterText = null;
+            UnfilteredCount = 0;
+
+            await ReloadAsync(cancellationToken);
+
+            if (string.IsNullOrEmpty(FilterText))
+            {
+                UnfilteredCount = TotalCount;
+            }
+        }
+
+        public async Task ApplyFilterAsync(string filterText, IEnumerable<string> columns, CancellationToken cancellationToken = default)
+        {
+            _rawFilterText = filterText;
+            _filterColumns = new List<string>(columns);
+
+            if (string.IsNullOrWhiteSpace(filterText))
+            {
+                FilterText = null;
+            }
+            else
+            {
+                var clauses = new List<string>();
+                string safeFilter = filterText.Replace("'", "''");
+                foreach (var col in columns)
+                {
+                    if (_columnSqlTypes.TryGetValue(col, out string type) && SafeStringTypes.Contains(type))
+                    {
+                        clauses.Add($"[{col}] LIKE '%{safeFilter}%'");
+                    }
+                    else
+                    {
+                        clauses.Add($"CAST([{col}] AS NVARCHAR(MAX)) LIKE '%{safeFilter}%'");
+                    }
+                }
+                FilterText = string.Join(" OR ", clauses);
+            }
+
+            await ReloadAsync(cancellationToken);
+        }
+
+        public async Task<long> GetTotalMatchCountAsync(CancellationToken cancellationToken = default)
+        {
+            if (string.IsNullOrWhiteSpace(_rawFilterText) || _filterColumns == null || _filterColumns.Count == 0)
+                return 0;
+
+            var colTypes = new Dictionary<string, string>();
+            foreach(var col in _filterColumns)
+            {
+                if(_columnSqlTypes.TryGetValue(col, out string type)) colTypes[col] = type;
+                else colTypes[col] = null;
+            }
+
+            return await _repo.GetTotalMatchCountAsync(_server, _database, _user, _pass, _baseSql, _parameters, FilterText, _rawFilterText, colTypes, cancellationToken);
+        }
+
+        public async Task<long> GetPrecedingMatchCountAsync(int limitRowIndex, CancellationToken cancellationToken = default)
+        {
+            if (string.IsNullOrWhiteSpace(_rawFilterText) || _filterColumns == null || _filterColumns.Count == 0 || limitRowIndex <= 0)
+                return 0;
+
+            var colTypes = new Dictionary<string, string>();
+            foreach (var col in _filterColumns)
+            {
+                if (_columnSqlTypes.TryGetValue(col, out string type)) colTypes[col] = type;
+                else colTypes[col] = null;
+            }
+
+            return await _repo.GetPrecedingMatchCountAsync(_server, _database, _user, _pass, _baseSql, _parameters, FilterText, _rawFilterText, colTypes, limitRowIndex, SortColumn, SortDirection, cancellationToken);
+        }
+
+        public async Task WaitForRowAsync(int rowIndex)
+        {
+            if (_cache.ContainsKey(rowIndex)) return;
+            GetValue(rowIndex, 0); // Trigger fetch
+            if (_cache.ContainsKey(rowIndex)) return;
+
+            int pageIndex = rowIndex / PageSize;
+            TaskCompletionSource<bool> tcs;
+
+            if (!_pageCompletionSources.TryGetValue(pageIndex, out tcs))
+            {
+                tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+                _pageCompletionSources[pageIndex] = tcs;
+            }
+
+            var timeoutTask = Task.Delay(5000);
+            await Task.WhenAny(tcs.Task, timeoutTask);
+        }
+
+        public async Task EnsureRangeLoadedAsync(int startIndex, int count)
+        {
+            if (count <= 0) return;
+            var tasks = new List<Task>();
+            int endRow = startIndex + count;
+
+            for (int i = startIndex; i < endRow; i += PageSize)
+            {
+                GetValue(i, 0);
+            }
+
+            for (int i = startIndex; i < endRow; i += PageSize)
+            {
+                tasks.Add(WaitForRowAsync(i));
+            }
+
+            await Task.WhenAll(tasks);
+        }
+
+        public async Task ApplySortAsync(string column, CancellationToken cancellationToken = default)
+        {
+            if (SortColumn == column)
+            {
+                SortDirection = SortDirection == "ASC" ? "DESC" : "ASC";
+            }
+            else
+            {
+                SortColumn = column;
+                SortDirection = "ASC";
+            }
+
+            await ReloadAsync(cancellationToken);
+        }
+
+        private async Task ReloadAsync(CancellationToken cancellationToken = default)
+        {
+            _version++;
+            int currentVersion = _version;
+
+            try
+            {
+                _cache.Clear();
+                _pagesBeingFetched.Clear();
+                _pageCompletionSources.Clear();
+
+                TotalCount = await _repo.GetQueryCountAsync(_server, _database, _user, _pass, _baseSql, _parameters, FilterText, cancellationToken);
+
+                if (_version == currentVersion)
+                {
+                    DataReady?.Invoke(this, EventArgs.Empty);
+                }
+            }
+            catch (OperationCanceledException) { }
+            catch (Exception ex)
+            {
+                LoadError?.Invoke(this, ex.Message);
+            }
+        }
+
+        public object GetValue(int rowIndex, int colIndex)
+        {
+            if (_cache.TryGetValue(rowIndex, out DataRow row))
+            {
+                if (colIndex >= 0 && colIndex < row.Table.Columns.Count)
+                    return row[colIndex];
+                return "";
+            }
+
+            RequestPage(rowIndex);
+            return null;
+        }
+
+        private async void RequestPage(int rowIndex)
+        {
+            int pageIndex = rowIndex / PageSize;
+
+            if (_pagesBeingFetched.Contains(pageIndex)) return;
+
+            int currentVersion = _version;
+            _pagesBeingFetched.Add(pageIndex);
+
+            try
+            {
+                int offset = pageIndex * PageSize;
+
+                string sortCol = SortColumn;
+                string sortDir = SortDirection;
+                string filter = FilterText;
+
+                var dt = await _repo.GetQueryPageAsync(_server, _database, _user, _pass, _baseSql, _parameters, offset, PageSize, sortCol, sortDir, filter);
+
+                if (_version != currentVersion) return;
+
+                for (int i = 0; i < dt.Rows.Count; i++)
+                {
+                    int absIndex = offset + i;
+                    _cache[absIndex] = dt.Rows[i];
+                }
+
+                DataReady?.Invoke(this, EventArgs.Empty);
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine("Page fetch error: " + ex.Message);
+            }
+            finally
+            {
+                if (_version == currentVersion)
+                {
+                    _pagesBeingFetched.Remove(pageIndex);
+
+                    if (_pageCompletionSources.TryGetValue(pageIndex, out var tcs))
+                    {
+                        tcs.TrySetResult(true);
+                        _pageCompletionSources.Remove(pageIndex);
+                    }
+                }
+            }
+        }
+
+        public async Task<DataTable> GetSchemaAsync(string sql, object parameters, CancellationToken cancellationToken = default)
+        {
+             var dt = await _repo.GetQuerySchemaAsync(_server, _database, _user, _pass, sql, parameters, cancellationToken);
+             _columnSqlTypes.Clear();
+             foreach(DataColumn col in dt.Columns)
+             {
+                 if(col.ExtendedProperties.ContainsKey("SqlType"))
+                 {
+                     _columnSqlTypes[col.ColumnName] = col.ExtendedProperties["SqlType"] as string;
+                 }
+             }
+             return dt;
+        }
+
+        private string BuildExportSql()
+        {
+             string finalSql = _baseSql;
+             if (!string.IsNullOrWhiteSpace(FilterText))
+             {
+                 finalSql = $"SELECT * FROM ({_baseSql}) AS _FilterQ WHERE {FilterText}";
+             }
+
+             if (!string.IsNullOrEmpty(SortColumn))
+             {
+                string safeCol = SortColumn.Replace("[", "").Replace("]", "");
+                if (string.IsNullOrWhiteSpace(FilterText))
+                {
+                    finalSql = $"SELECT * FROM ({finalSql}) AS _SortQ ORDER BY [{safeCol}] {SortDirection}";
+                }
+                else
+                {
+                    finalSql += $" ORDER BY [{safeCol}] {SortDirection}";
+                }
+             }
+             return finalSql;
+        }
+
+        public async Task ExportToCsvAsync(string filename, Dictionary<string, string> headerMap = null, bool includeHeaders = true, CancellationToken cancellationToken = default)
+        {
+             string finalSql = BuildExportSql();
+
+             using (var reader = await _repo.GetQueryDataReaderAsync(_server, _database, _user, _pass, finalSql, _parameters, cancellationToken))
+             {
+                 using (var writer = new StreamWriter(filename))
+                 {
+                     if (includeHeaders)
+                     {
+                         for (int i = 0; i < reader.FieldCount; i++)
+                         {
+                             if (i > 0) writer.Write(",");
+                             string colName = reader.GetName(i);
+                             string header = (headerMap != null && headerMap.ContainsKey(colName)) ? headerMap[colName] : colName;
+                             writer.Write("\"" + header.Replace("\"", "\"\"") + "\"");
+                         }
+                         writer.WriteLine();
+                     }
+
+                     while (await reader.ReadAsync(cancellationToken))
+                     {
+                         for (int i = 0; i < reader.FieldCount; i++)
+                         {
+                             if (i > 0) writer.Write(",");
+                             var val = reader.GetValue(i);
+                             string sVal = val == DBNull.Value ? "" : val.ToString();
+                             writer.Write("\"" + sVal.Replace("\"", "\"\"") + "\"");
+                         }
+                         writer.WriteLine();
+                     }
+                 }
+             }
+        }
+
+        public async Task ExportToJsonAsync(string filename, Dictionary<string, string> headerMap = null, CancellationToken cancellationToken = default)
+        {
+             string finalSql = BuildExportSql();
+
+             using (var reader = await _repo.GetQueryDataReaderAsync(_server, _database, _user, _pass, finalSql, _parameters, cancellationToken))
+             {
+                 using (var fs = new FileStream(filename, FileMode.Create, FileAccess.Write, FileShare.None))
+                 using (var writer = new Utf8JsonWriter(fs, new JsonWriterOptions { Indented = true }))
+                 {
+                     writer.WriteStartArray();
+                     while (await reader.ReadAsync(cancellationToken))
+                     {
+                         writer.WriteStartObject();
+                         for (int i = 0; i < reader.FieldCount; i++)
+                         {
+                             string colName = reader.GetName(i);
+                             string header = (headerMap != null && headerMap.ContainsKey(colName)) ? headerMap[colName] : colName;
+                             var val = reader.GetValue(i);
+
+                             writer.WritePropertyName(header);
+
+                             if (val == DBNull.Value) writer.WriteNullValue();
+                             else if (val is bool b) writer.WriteBooleanValue(b);
+                             else if (IsNumeric(val)) writer.WriteNumberValue(Convert.ToDecimal(val));
+                             else writer.WriteStringValue(val.ToString());
+                         }
+                         writer.WriteEndObject();
+                     }
+                     writer.WriteEndArray();
+                 }
+             }
+        }
+
+        public async Task ExportToExcelXmlAsync(string filename, Dictionary<string, string> headerMap = null, CancellationToken cancellationToken = default)
+        {
+             string finalSql = BuildExportSql();
+
+             using (var reader = await _repo.GetQueryDataReaderAsync(_server, _database, _user, _pass, finalSql, _parameters, cancellationToken))
+             {
+                 using (var writer = new StreamWriter(filename))
+                 {
+                     writer.WriteLine("<?xml version=\"1.0\"?>");
+                     writer.WriteLine("<?mso-application progid=\"Excel.Sheet\"?>");
+                     writer.WriteLine("<Workbook xmlns=\"urn:schemas-microsoft-com:office:spreadsheet\"");
+                     writer.WriteLine(" xmlns:o=\"urn:schemas-microsoft-com:office:office\"");
+                     writer.WriteLine(" xmlns:x=\"urn:schemas-microsoft-com:office:excel\"");
+                     writer.WriteLine(" xmlns:ss=\"urn:schemas-microsoft-com:office:spreadsheet\"");
+                     writer.WriteLine(" xmlns:html=\"http://www.w3.org/TR/REC-html40\">");
+                     writer.WriteLine(" <Worksheet ss:Name=\"Sheet1\">");
+                     writer.WriteLine("  <Table>");
+
+                     writer.WriteLine("   <Row>");
+                     for (int i = 0; i < reader.FieldCount; i++)
+                     {
+                         string colName = reader.GetName(i);
+                         string header = (headerMap != null && headerMap.ContainsKey(colName)) ? headerMap[colName] : colName;
+                         writer.WriteLine($"    <Cell><Data ss:Type=\"String\">{EscapeXml(header)}</Data></Cell>");
+                     }
+                     writer.WriteLine("   </Row>");
+
+                     while (await reader.ReadAsync(cancellationToken))
+                     {
+                         writer.WriteLine("   <Row>");
+                         for (int i = 0; i < reader.FieldCount; i++)
+                         {
+                             var val = reader.GetValue(i);
+                             if (val == DBNull.Value)
+                             {
+                                 writer.WriteLine("    <Cell></Cell>");
+                             }
+                             else
+                             {
+                                 writer.WriteLine($"    <Cell><Data ss:Type=\"String\">{EscapeXml(val.ToString())}</Data></Cell>");
+                             }
+                         }
+                         writer.WriteLine("   </Row>");
+                     }
+
+                     writer.WriteLine("  </Table>");
+                     writer.WriteLine(" </Worksheet>");
+                     writer.WriteLine("</Workbook>");
+                 }
+             }
+        }
+
+        private string EscapeXml(string s)
+        {
+            if (string.IsNullOrEmpty(s)) return "";
+            return s.Replace("&", "&amp;").Replace("<", "&lt;").Replace(">", "&gt;").Replace("\"", "&quot;").Replace("'", "&apos;");
+        }
+
+        private bool IsNumeric(object value)
+        {
+            return value is sbyte || value is byte || value is short || value is ushort ||
+                   value is int || value is uint || value is long || value is ulong ||
+                   value is float || value is double || value is decimal;
+        }
+
+        public async Task<int> FindMatchRowAsync(string searchText, IEnumerable<string> searchColumns, int startRowIndex, bool forward, CancellationToken cancellationToken = default)
+        {
+            if (string.IsNullOrWhiteSpace(searchText) || searchColumns == null) return -1;
+
+            var colTypes = new Dictionary<string, string>();
+            foreach (var col in searchColumns)
+            {
+                if (_columnSqlTypes.TryGetValue(col, out string type)) colTypes[col] = type;
+                else colTypes[col] = null;
+            }
+
+            return await _repo.GetMatchRowIndexAsync(_server, _database, _user, _pass, _baseSql, _parameters, FilterText, searchText, colTypes, startRowIndex, SortColumn, SortDirection, forward, cancellationToken);
+        }
+    }
+}

--- a/SMS_Search_WPF/SMSSearch/Data/VirtualRow.cs
+++ b/SMS_Search_WPF/SMSSearch/Data/VirtualRow.cs
@@ -1,0 +1,63 @@
+using System;
+using System.ComponentModel;
+
+namespace SMS_Search.Data
+{
+    public class VirtualRow : CustomTypeDescriptor
+    {
+        private readonly VirtualGridContext _context;
+        private readonly int _rowIndex;
+        private readonly PropertyDescriptorCollection _properties;
+
+        public VirtualRow(VirtualGridContext context, int rowIndex, PropertyDescriptorCollection properties)
+        {
+            _context = context;
+            _rowIndex = rowIndex;
+            _properties = properties;
+        }
+
+        public override PropertyDescriptorCollection GetProperties()
+        {
+            return _properties;
+        }
+
+        public override PropertyDescriptorCollection GetProperties(Attribute[] attributes)
+        {
+            return _properties;
+        }
+
+        public object GetValue(int colIndex)
+        {
+            return _context.GetValue(_rowIndex, colIndex);
+        }
+    }
+
+    public class VirtualPropertyDescriptor : PropertyDescriptor
+    {
+        private readonly int _colIndex;
+        private readonly Type _colType;
+
+        public VirtualPropertyDescriptor(string name, int colIndex, Type colType)
+            : base(name, null)
+        {
+            _colIndex = colIndex;
+            _colType = colType;
+        }
+
+        public override Type ComponentType => typeof(VirtualRow);
+        public override bool IsReadOnly => true;
+        public override Type PropertyType => _colType;
+        public override bool CanResetValue(object component) => false;
+        public override object GetValue(object component)
+        {
+            if (component is VirtualRow row)
+            {
+                return row.GetValue(_colIndex);
+            }
+            return null;
+        }
+        public override void ResetValue(object component) { }
+        public override void SetValue(object component, object value) { }
+        public override bool ShouldSerializeValue(object component) => false;
+    }
+}

--- a/SMS_Search_WPF/SMSSearch/Data/VirtualizingCollection.cs
+++ b/SMS_Search_WPF/SMSSearch/Data/VirtualizingCollection.cs
@@ -1,0 +1,76 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.ComponentModel;
+using System.Data;
+
+namespace SMS_Search.Data
+{
+    public class VirtualizingCollection : IList, ITypedList, INotifyCollectionChanged
+    {
+        private readonly VirtualGridContext _context;
+        private readonly PropertyDescriptorCollection _properties;
+
+        public event NotifyCollectionChangedEventHandler CollectionChanged;
+
+        public VirtualizingCollection(VirtualGridContext context, DataTable schema)
+        {
+            _context = context;
+
+            var props = new List<PropertyDescriptor>();
+            for (int i = 0; i < schema.Columns.Count; i++)
+            {
+                props.Add(new VirtualPropertyDescriptor(schema.Columns[i].ColumnName, i, schema.Columns[i].DataType));
+            }
+            _properties = new PropertyDescriptorCollection(props.ToArray());
+        }
+
+        public void Refresh()
+        {
+            CollectionChanged?.Invoke(this, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset));
+        }
+
+        public int Count => _context.TotalCount;
+
+        public bool IsFixedSize => true;
+
+        public bool IsReadOnly => true;
+
+        public bool IsSynchronized => false;
+
+        public object SyncRoot => this;
+
+        public object this[int index]
+        {
+            get => new VirtualRow(_context, index, _properties);
+            set => throw new NotSupportedException();
+        }
+
+        public int Add(object value) => throw new NotSupportedException();
+        public void Clear() => throw new NotSupportedException();
+        public bool Contains(object value) => false;
+        public void CopyTo(Array array, int index) => throw new NotSupportedException();
+        public IEnumerator GetEnumerator()
+        {
+            for (int i = 0; i < Count; i++)
+            {
+                yield return this[i];
+            }
+        }
+        public int IndexOf(object value) => -1;
+        public void Insert(int index, object value) => throw new NotSupportedException();
+        public void Remove(object value) => throw new NotSupportedException();
+        public void RemoveAt(int index) => throw new NotSupportedException();
+
+        public PropertyDescriptorCollection GetItemProperties(PropertyDescriptor[] listAccessors)
+        {
+            return _properties;
+        }
+
+        public string GetListName(PropertyDescriptor[] listAccessors)
+        {
+            return "VirtualList";
+        }
+    }
+}

--- a/SMS_Search_WPF/SMSSearch/MainWindow.xaml
+++ b/SMS_Search_WPF/SMSSearch/MainWindow.xaml
@@ -1,0 +1,32 @@
+<Window x:Class="SMS_Search.MainWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:local="clr-namespace:SMS_Search"
+        xmlns:views="clr-namespace:SMS_Search.Views"
+        xmlns:vm="clr-namespace:SMS_Search.ViewModels"
+        mc:Ignorable="d"
+        d:DataContext="{d:DesignInstance Type=vm:MainViewModel}"
+        Title="SMS Search" Height="600" Width="800">
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+        </Grid.RowDefinitions>
+
+        <GroupBox Header="Search Criteria" Margin="10">
+            <StackPanel>
+                <DockPanel LastChildFill="False">
+                    <Button Content="Settings" Command="{Binding OpenSettingsCommand}" DockPanel.Dock="Left" Padding="10,5"/>
+                    <Button Content="Search" Command="{Binding ExecuteSearchCommand}"
+                            DockPanel.Dock="Right" Padding="20,5"
+                            IsDefault="True"/>
+                </DockPanel>
+                <views:SearchView DataContext="{Binding SearchViewModel}" Margin="0,5,0,0"/>
+            </StackPanel>
+        </GroupBox>
+
+        <views:ResultsView Grid.Row="1" DataContext="{Binding ResultsViewModel}" Margin="10,0,10,10"/>
+    </Grid>
+</Window>

--- a/SMS_Search_WPF/SMSSearch/MainWindow.xaml.cs
+++ b/SMS_Search_WPF/SMSSearch/MainWindow.xaml.cs
@@ -1,0 +1,24 @@
+using System.Windows;
+using SMS_Search.ViewModels;
+using Microsoft.Extensions.DependencyInjection;
+using SMS_Search.Views;
+
+namespace SMS_Search
+{
+    public partial class MainWindow : Window
+    {
+        public MainWindow(MainViewModel viewModel)
+        {
+            InitializeComponent();
+            DataContext = viewModel;
+            viewModel.RequestOpenSettings += OnRequestOpenSettings;
+        }
+
+        private void OnRequestOpenSettings()
+        {
+            var win = App.Current.Services.GetRequiredService<SettingsWindow>();
+            win.Owner = this;
+            win.ShowDialog();
+        }
+    }
+}

--- a/SMS_Search_WPF/SMSSearch/SMSSearch.csproj
+++ b/SMS_Search_WPF/SMSSearch/SMSSearch.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net10.0-windows</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <UseWPF>true</UseWPF>
+    <PublishSingleFile>true</PublishSingleFile>
+    <SelfContained>true</SelfContained>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.3.2" />
+    <PackageReference Include="Dapper" Version="2.1.35" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.8.6" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0" />
+    <PackageReference Include="Serilog" Version="4.0.0" />
+    <PackageReference Include="Serilog.Sinks.File" Version="6.0.0" />
+    <PackageReference Include="System.Text.Json" Version="8.0.5" />
+  </ItemGroup>
+
+</Project>

--- a/SMS_Search_WPF/SMSSearch/Services/ClipboardService.cs
+++ b/SMS_Search_WPF/SMSSearch/Services/ClipboardService.cs
@@ -1,0 +1,28 @@
+using System.Windows;
+using System.Runtime.InteropServices;
+
+namespace SMS_Search.Services
+{
+    public class ClipboardService : IClipboardService
+    {
+        public void SetText(string text)
+        {
+            if (string.IsNullOrEmpty(text)) return;
+            try
+            {
+                Clipboard.SetText(text);
+            }
+            catch (ExternalException)
+            {
+                // Clipboard can be locked by another process
+            }
+        }
+
+        public string GetText()
+        {
+            if (Clipboard.ContainsText())
+                return Clipboard.GetText();
+            return string.Empty;
+        }
+    }
+}

--- a/SMS_Search_WPF/SMSSearch/Services/DialogService.cs
+++ b/SMS_Search_WPF/SMSSearch/Services/DialogService.cs
@@ -1,0 +1,42 @@
+using System.Windows;
+using Microsoft.Win32;
+
+namespace SMS_Search.Services
+{
+    public class DialogService : IDialogService
+    {
+        public void ShowMessage(string message, string title)
+        {
+            MessageBox.Show(message, title, MessageBoxButton.OK, MessageBoxImage.Information);
+        }
+
+        public void ShowError(string message, string title)
+        {
+            MessageBox.Show(message, title, MessageBoxButton.OK, MessageBoxImage.Error);
+        }
+
+        public bool ShowConfirmation(string message, string title)
+        {
+            return MessageBox.Show(message, title, MessageBoxButton.YesNo, MessageBoxImage.Question) == MessageBoxResult.Yes;
+        }
+
+        public string OpenFileDialog(string filter)
+        {
+            var dlg = new OpenFileDialog { Filter = filter };
+            if (dlg.ShowDialog() == true) return dlg.FileName;
+            return null;
+        }
+
+        public string SaveFileDialog(string filter, string defaultName = "")
+        {
+            var dlg = new SaveFileDialog { Filter = filter, FileName = defaultName };
+            if (dlg.ShowDialog() == true) return dlg.FileName;
+            return null;
+        }
+
+        public void ShowToast(string message, string title)
+        {
+            MessageBox.Show(message, title, MessageBoxButton.OK, MessageBoxImage.Information);
+        }
+    }
+}

--- a/SMS_Search_WPF/SMSSearch/Services/HotkeyService.cs
+++ b/SMS_Search_WPF/SMSSearch/Services/HotkeyService.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Runtime.InteropServices;
+using System.Windows.Input;
+using System.Windows.Interop;
+using SMS_Search.Utils;
+
+namespace SMS_Search.Services
+{
+    public class HotkeyService : IHotkeyService
+    {
+        private const int WM_HOTKEY = 0x0312;
+        private const int HOTKEY_ID = 9000;
+        private Action _action;
+        private bool _isRegistered;
+        private IntPtr _hwnd;
+        private readonly ILoggerService _logger;
+
+        [DllImport("user32.dll")]
+        private static extern bool RegisterHotKey(IntPtr hWnd, int id, uint fsModifiers, uint vk);
+
+        [DllImport("user32.dll")]
+        private static extern bool UnregisterHotKey(IntPtr hWnd, int id);
+
+        public HotkeyService(ILoggerService logger)
+        {
+            _logger = logger;
+        }
+
+        public void Register(IntPtr hwnd, Key key, ModifierKeys modifiers, Action action)
+        {
+            if (_isRegistered) Unregister();
+
+            _hwnd = hwnd;
+            _action = action;
+
+            int vkey = KeyInterop.VirtualKeyFromKey(key);
+            uint fsModifiers = 0;
+            if ((modifiers & ModifierKeys.Alt) == ModifierKeys.Alt) fsModifiers |= 1;
+            if ((modifiers & ModifierKeys.Control) == ModifierKeys.Control) fsModifiers |= 2;
+            if ((modifiers & ModifierKeys.Shift) == ModifierKeys.Shift) fsModifiers |= 4;
+            if ((modifiers & ModifierKeys.Windows) == ModifierKeys.Windows) fsModifiers |= 8;
+
+            if (RegisterHotKey(_hwnd, HOTKEY_ID, fsModifiers, (uint)vkey))
+            {
+                _isRegistered = true;
+                _logger.LogInfo($"Global hotkey registered: {modifiers}+{key}");
+            }
+            else
+            {
+                _logger.LogError("Failed to register global hotkey.");
+            }
+        }
+
+        public void Unregister()
+        {
+            if (_isRegistered && _hwnd != IntPtr.Zero)
+            {
+                UnregisterHotKey(_hwnd, HOTKEY_ID);
+                _isRegistered = false;
+                _logger.LogInfo("Global hotkey unregistered.");
+            }
+        }
+
+        public void ProcessMessage(IntPtr hwnd, int msg, IntPtr wParam, IntPtr lParam, ref bool handled)
+        {
+            if (msg == WM_HOTKEY && wParam.ToInt32() == HOTKEY_ID)
+            {
+                _logger.LogInfo("Global hotkey triggered.");
+                _action?.Invoke();
+                handled = true;
+            }
+        }
+    }
+}

--- a/SMS_Search_WPF/SMSSearch/Services/IClipboardService.cs
+++ b/SMS_Search_WPF/SMSSearch/Services/IClipboardService.cs
@@ -1,0 +1,8 @@
+namespace SMS_Search.Services
+{
+    public interface IClipboardService
+    {
+        void SetText(string text);
+        string GetText();
+    }
+}

--- a/SMS_Search_WPF/SMSSearch/Services/IDialogService.cs
+++ b/SMS_Search_WPF/SMSSearch/Services/IDialogService.cs
@@ -1,0 +1,14 @@
+using System.Threading.Tasks;
+
+namespace SMS_Search.Services
+{
+    public interface IDialogService
+    {
+        void ShowMessage(string message, string title);
+        void ShowError(string message, string title);
+        bool ShowConfirmation(string message, string title);
+        string OpenFileDialog(string filter);
+        string SaveFileDialog(string filter, string defaultName = "");
+        void ShowToast(string message, string title);
+    }
+}

--- a/SMS_Search_WPF/SMSSearch/Services/IHotkeyService.cs
+++ b/SMS_Search_WPF/SMSSearch/Services/IHotkeyService.cs
@@ -1,0 +1,12 @@
+using System;
+using System.Windows.Input;
+
+namespace SMS_Search.Services
+{
+    public interface IHotkeyService
+    {
+        void Register(IntPtr hwnd, Key key, ModifierKeys modifiers, Action action);
+        void Unregister();
+        void ProcessMessage(IntPtr hwnd, int msg, IntPtr wParam, IntPtr lParam, ref bool handled);
+    }
+}

--- a/SMS_Search_WPF/SMSSearch/Utils/ConfigManager.cs
+++ b/SMS_Search_WPF/SMSSearch/Utils/ConfigManager.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+namespace SMS_Search.Utils
+{
+    public interface IConfigService
+    {
+        string GetValue(string section, string key);
+        void SetValue(string section, string key, string value);
+        void Save();
+        void Load();
+    }
+
+    public class ConfigManager : IConfigService
+    {
+        private Dictionary<string, Dictionary<string, string>> _config;
+        private readonly string _filePath;
+
+        public ConfigManager(string filePath)
+        {
+            _filePath = filePath;
+            Load();
+        }
+
+        public string GetValue(string section, string key)
+        {
+            if (_config.TryGetValue(section, out var sectionDict))
+            {
+                if (sectionDict.TryGetValue(key, out var value))
+                {
+                    return value;
+                }
+            }
+            return null;
+        }
+
+        public void SetValue(string section, string key, string value)
+        {
+            if (!_config.ContainsKey(section))
+            {
+                _config[section] = new Dictionary<string, string>();
+            }
+            _config[section][key] = value;
+        }
+
+        public void Load()
+        {
+            if (File.Exists(_filePath))
+            {
+                try
+                {
+                    var json = File.ReadAllText(_filePath);
+                    _config = JsonSerializer.Deserialize<Dictionary<string, Dictionary<string, string>>>(json)
+                              ?? new Dictionary<string, Dictionary<string, string>>();
+                }
+                catch
+                {
+                    _config = new Dictionary<string, Dictionary<string, string>>();
+                }
+            }
+            else
+            {
+                _config = new Dictionary<string, Dictionary<string, string>>();
+            }
+        }
+
+        public void Save()
+        {
+            var options = new JsonSerializerOptions { WriteIndented = true };
+            var json = JsonSerializer.Serialize(_config, options);
+            File.WriteAllText(_filePath, json);
+        }
+    }
+}

--- a/SMS_Search_WPF/SMSSearch/Utils/GeneralUtils.cs
+++ b/SMS_Search_WPF/SMSSearch/Utils/GeneralUtils.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Text;
+using System.Security.Cryptography;
+
+namespace SMS_Search.Utils
+{
+    public static class GeneralUtils
+    {
+        public static string Encrypt(string sLine)
+        {
+            if (string.IsNullOrEmpty(sLine)) return "";
+            try
+            {
+                byte[] data = Encoding.UTF8.GetBytes(sLine);
+                byte[] encrypted = ProtectedData.Protect(data, null, DataProtectionScope.CurrentUser);
+                return Convert.ToBase64String(encrypted);
+            }
+            catch
+            {
+                return "";
+            }
+        }
+
+        public static string Decrypt(string sLine)
+        {
+            if (string.IsNullOrEmpty(sLine)) return "";
+            if (sLine.StartsWith("#")) return "";
+
+            try
+            {
+                byte[] data = Convert.FromBase64String(sLine);
+                byte[] decrypted = ProtectedData.Unprotect(data, null, DataProtectionScope.CurrentUser);
+                return Encoding.UTF8.GetString(decrypted);
+            }
+            catch
+            {
+                return "";
+            }
+        }
+    }
+}

--- a/SMS_Search_WPF/SMSSearch/Utils/HotkeyUtils.cs
+++ b/SMS_Search_WPF/SMSSearch/Utils/HotkeyUtils.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Windows.Input;
+
+namespace SMS_Search.Utils
+{
+    public static class HotkeyUtils
+    {
+        public static (Key Key, ModifierKeys Modifiers) Parse(string input)
+        {
+             if (string.IsNullOrWhiteSpace(input)) return (Key.None, ModifierKeys.None);
+
+             ModifierKeys modifiers = ModifierKeys.None;
+             Key key = Key.None;
+
+             var parts = input.Split(new[] { '+', ',' }, StringSplitOptions.RemoveEmptyEntries);
+             foreach (var part in parts)
+             {
+                 var p = part.Trim().ToUpperInvariant();
+                 if (p == "CTRL" || p == "CONTROL" || p == "<CTRL>") modifiers |= ModifierKeys.Control;
+                 else if (p == "ALT" || p == "<ALT>") modifiers |= ModifierKeys.Alt;
+                 else if (p == "SHIFT" || p == "<SHIFT>") modifiers |= ModifierKeys.Shift;
+                 else if (p == "WIN" || p == "WINDOWS") modifiers |= ModifierKeys.Windows;
+                 else
+                 {
+                     try {
+                         if (Enum.TryParse(p.Replace("<", "").Replace(">", ""), true, out Key k))
+                         {
+                             key = k;
+                         }
+                     } catch {}
+                 }
+             }
+
+             return (key, modifiers);
+        }
+    }
+}

--- a/SMS_Search_WPF/SMSSearch/Utils/LoggerService.cs
+++ b/SMS_Search_WPF/SMSSearch/Utils/LoggerService.cs
@@ -1,0 +1,58 @@
+using System;
+using Serilog;
+
+namespace SMS_Search.Utils
+{
+    public interface ILoggerService
+    {
+        void Log(LogLevel level, string message);
+        void LogError(string message, Exception ex = null);
+        void LogInfo(string message);
+        void LogDebug(string message);
+    }
+
+    public enum LogLevel
+    {
+        Debug,
+        Info,
+        Warning,
+        Error,
+        Critical
+    }
+
+    public class LoggerService : ILoggerService
+    {
+        private readonly Serilog.ILogger _logger;
+
+        public LoggerService(string appName)
+        {
+            _logger = new LoggerConfiguration()
+                .MinimumLevel.Debug()
+                .WriteTo.File($"logs/{appName}_.log", rollingInterval: RollingInterval.Day, retainedFileCountLimit: 14)
+                .CreateLogger();
+        }
+
+        public void Log(LogLevel level, string message)
+        {
+             switch (level)
+             {
+                 case LogLevel.Debug: _logger.Debug(message); break;
+                 case LogLevel.Info: _logger.Information(message); break;
+                 case LogLevel.Warning: _logger.Warning(message); break;
+                 case LogLevel.Error: _logger.Error(message); break;
+                 case LogLevel.Critical: _logger.Fatal(message); break;
+             }
+        }
+
+        public void LogError(string message, Exception ex = null)
+        {
+            if (ex != null)
+                _logger.Error(ex, message);
+            else
+                _logger.Error(message);
+        }
+
+        public void LogInfo(string message) => _logger.Information(message);
+        public void LogDebug(string message) => _logger.Debug(message);
+    }
+}

--- a/SMS_Search_WPF/SMSSearch/ViewModels/MainViewModel.cs
+++ b/SMS_Search_WPF/SMSSearch/ViewModels/MainViewModel.cs
@@ -1,0 +1,65 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using SMS_Search.Data;
+using SMS_Search.Services;
+using System;
+using System.Threading.Tasks;
+using System.Windows.Input;
+
+namespace SMS_Search.ViewModels
+{
+    public partial class MainViewModel : ObservableObject
+    {
+        private readonly ILoggerService _logger;
+        private readonly IDialogService _dialogService;
+        private readonly IConfigService _configService;
+        private readonly IQueryHistoryService _historyService;
+        private readonly IHotkeyService _hotkeyService;
+
+        public event Action RequestOpenSettings;
+
+        public MainViewModel(
+            SearchViewModel searchViewModel,
+            ResultsViewModel resultsViewModel,
+            ILoggerService logger,
+            IDialogService dialogService,
+            IConfigService configService,
+            IQueryHistoryService historyService,
+            IHotkeyService hotkeyService)
+        {
+            SearchViewModel = searchViewModel;
+            ResultsViewModel = resultsViewModel;
+            _logger = logger;
+            _dialogService = dialogService;
+            _configService = configService;
+            _historyService = historyService;
+            _hotkeyService = hotkeyService;
+
+            ExecuteSearchCommand = new AsyncRelayCommand(ExecuteSearch);
+            OpenSettingsCommand = new RelayCommand(OpenSettings);
+        }
+
+        public SearchViewModel SearchViewModel { get; }
+        public ResultsViewModel ResultsViewModel { get; }
+
+        public IAsyncRelayCommand ExecuteSearchCommand { get; }
+        public IRelayCommand OpenSettingsCommand { get; }
+
+        private async Task ExecuteSearch()
+        {
+             var criteria = SearchViewModel.GetSearchCriteria();
+
+             await ResultsViewModel.ExecuteSearchAsync(criteria);
+
+             if (criteria.Type == SearchType.CustomSql)
+             {
+                 _historyService.AddQuery(criteria.Mode.ToString(), criteria.Value);
+             }
+        }
+
+        private void OpenSettings()
+        {
+            RequestOpenSettings?.Invoke();
+        }
+    }
+}

--- a/SMS_Search_WPF/SMSSearch/ViewModels/ResultsViewModel.cs
+++ b/SMS_Search_WPF/SMSSearch/ViewModels/ResultsViewModel.cs
@@ -1,0 +1,159 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using SMS_Search.Data;
+using SMS_Search.Services;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Data;
+using System.Threading.Tasks;
+
+namespace SMS_Search.ViewModels
+{
+    public partial class ResultsViewModel : ObservableObject
+    {
+        private readonly VirtualGridContext _gridContext;
+        private readonly ILoggerService _logger;
+        private readonly IDialogService _dialogService;
+        private readonly QueryBuilder _queryBuilder;
+        private readonly IConfigService _configService;
+
+        public ResultsViewModel(VirtualGridContext gridContext, ILoggerService logger, IDialogService dialogService, IConfigService configService)
+        {
+            _gridContext = gridContext;
+            _logger = logger;
+            _dialogService = dialogService;
+            _configService = configService;
+
+            string fctFields = _configService.GetValue("QUERY", "FUNCTION");
+            string tlzFields = _configService.GetValue("QUERY", "TOTALIZER");
+            _queryBuilder = new QueryBuilder(fctFields, tlzFields);
+
+            _gridContext.DataReady += OnDataReady;
+            _gridContext.LoadError += OnLoadError;
+
+            ExportCsvCommand = new AsyncRelayCommand(ExportCsvAsync);
+            ExportJsonCommand = new AsyncRelayCommand(ExportJsonAsync);
+            ExportExcelCommand = new AsyncRelayCommand(ExportExcelAsync);
+        }
+
+        [ObservableProperty]
+        private IList _searchResults;
+
+        [ObservableProperty]
+        private bool _isBusy;
+
+        [ObservableProperty]
+        private string _statusText;
+
+        [ObservableProperty]
+        private int _totalRecords;
+
+        public IAsyncRelayCommand ExportCsvCommand { get; }
+        public IAsyncRelayCommand ExportJsonCommand { get; }
+        public IAsyncRelayCommand ExportExcelCommand { get; }
+
+        private void OnDataReady(object sender, EventArgs e)
+        {
+            System.Windows.Application.Current.Dispatcher.Invoke(() =>
+            {
+                if (SearchResults is VirtualizingCollection vc)
+                {
+                    vc.Refresh();
+                    TotalRecords = _gridContext.TotalCount;
+                    StatusText = $"Found {TotalRecords} records";
+                }
+            });
+        }
+
+        private void OnLoadError(object sender, string msg)
+        {
+            System.Windows.Application.Current.Dispatcher.Invoke(() =>
+            {
+                _dialogService.ShowError(msg, "Data Load Error");
+                StatusText = "Error loading data";
+            });
+        }
+
+        public async Task ExecuteSearchAsync(SearchCriteria criteria)
+        {
+            IsBusy = true;
+            StatusText = "Searching...";
+
+            try
+            {
+                var queryResult = _queryBuilder.Build(criteria);
+
+                var server = _configService.GetValue("CONNECTION", "SERVER");
+                var database = _configService.GetValue("CONNECTION", "DATABASE");
+                var user = _configService.GetValue("CONNECTION", "SQLUSER");
+                var pass = _configService.GetValue("CONNECTION", "SQLPASSWORD");
+                string decryptedPass = !string.IsNullOrEmpty(pass) ? SMS_Search.Utils.GeneralUtils.Decrypt(pass) : null;
+
+                _gridContext.SetConnection(server, database, user, decryptedPass);
+
+                // Load initial count and cache schema
+                var schema = await _gridContext.GetSchemaAsync(queryResult.Sql, queryResult.Parameters);
+                await _gridContext.LoadAsync(queryResult.Sql, queryResult.Parameters);
+
+                // Create new collection
+                SearchResults = new VirtualizingCollection(_gridContext, schema);
+
+                TotalRecords = _gridContext.TotalCount;
+                StatusText = $"Found {TotalRecords} records";
+            }
+            catch (Exception ex)
+            {
+                StatusText = "Error";
+                _dialogService.ShowError(ex.Message, "Search Failed");
+                _logger.LogError("Search failed", ex);
+            }
+            finally
+            {
+                IsBusy = false;
+            }
+        }
+
+        private async Task ExportCsvAsync()
+        {
+            string filename = _dialogService.SaveFileDialog("CSV files (*.csv)|*.csv", $"SMS_Search_Export_{DateTime.Now:yyyyMMdd_HHmmss}.csv");
+            if (string.IsNullOrEmpty(filename)) return;
+            await PerformExportAsync(() => _gridContext.ExportToCsvAsync(filename));
+        }
+
+        private async Task ExportJsonAsync()
+        {
+            string filename = _dialogService.SaveFileDialog("JSON files (*.json)|*.json", $"SMS_Search_Export_{DateTime.Now:yyyyMMdd_HHmmss}.json");
+            if (string.IsNullOrEmpty(filename)) return;
+            await PerformExportAsync(() => _gridContext.ExportToJsonAsync(filename));
+        }
+
+        private async Task ExportExcelAsync()
+        {
+            string filename = _dialogService.SaveFileDialog("Excel XML (*.xml)|*.xml", $"SMS_Search_Export_{DateTime.Now:yyyyMMdd_HHmmss}.xml");
+            if (string.IsNullOrEmpty(filename)) return;
+            await PerformExportAsync(() => _gridContext.ExportToExcelXmlAsync(filename));
+        }
+
+        private async Task PerformExportAsync(Func<Task> exportAction)
+        {
+            IsBusy = true;
+            StatusText = "Exporting...";
+            try
+            {
+                await exportAction();
+                _dialogService.ShowMessage("Export successful", "Export");
+            }
+            catch (Exception ex)
+            {
+                _dialogService.ShowError(ex.Message, "Export Error");
+                _logger.LogError("Export failed", ex);
+            }
+            finally
+            {
+                IsBusy = false;
+                StatusText = $"Found {TotalRecords} records";
+            }
+        }
+    }
+}

--- a/SMS_Search_WPF/SMSSearch/ViewModels/SearchViewModel.cs
+++ b/SMS_Search_WPF/SMSSearch/ViewModels/SearchViewModel.cs
@@ -1,0 +1,135 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using SMS_Search.Data;
+using SMS_Search.Services;
+using SMS_Search.Utils;
+using System.Collections.ObjectModel;
+using System.Threading.Tasks;
+
+namespace SMS_Search.ViewModels
+{
+    public partial class SearchViewModel : ObservableObject
+    {
+        private readonly IDataRepository _repository;
+        private readonly IDialogService _dialogService;
+        private readonly IConfigService _configService;
+        private readonly ILoggerService _logger;
+
+        public SearchViewModel(IDataRepository repository, IDialogService dialogService, IConfigService configService, ILoggerService logger)
+        {
+            _repository = repository;
+            _dialogService = dialogService;
+            _configService = configService;
+            _logger = logger;
+            LoadTablesCommand = new AsyncRelayCommand(LoadTablesAsync);
+        }
+
+        [ObservableProperty]
+        private SearchMode _selectedMode;
+
+        [ObservableProperty]
+        private string _searchText;
+
+        [ObservableProperty]
+        private bool _anyMatch;
+
+        // Function Tab Properties
+        [ObservableProperty]
+        private bool _isFunctionNumber = true;
+        [ObservableProperty]
+        private bool _isFunctionDescription;
+        [ObservableProperty]
+        private bool _isFunctionCustomSql;
+
+        // Totalizer Tab Properties
+        [ObservableProperty]
+        private bool _isTotalizerNumber = true;
+        [ObservableProperty]
+        private bool _isTotalizerDescription;
+        [ObservableProperty]
+        private bool _isTotalizerCustomSql;
+
+        // Field Tab Properties
+        [ObservableProperty]
+        private bool _isFieldNumber = true;
+        [ObservableProperty]
+        private bool _isFieldDescription;
+        [ObservableProperty]
+        private bool _isFieldTable;
+        [ObservableProperty]
+        private bool _isFieldCustomSql;
+
+        [ObservableProperty]
+        private ObservableCollection<string> _tables = new ObservableCollection<string>();
+
+        [ObservableProperty]
+        private string _selectedTable;
+
+        [ObservableProperty]
+        private bool _showFields = true;
+
+        [ObservableProperty]
+        private bool _showRecords;
+
+        [ObservableProperty]
+        private bool _lastTransaction;
+
+        public IAsyncRelayCommand LoadTablesCommand { get; }
+
+        private async Task LoadTablesAsync()
+        {
+            try
+            {
+                 var server = _configService.GetValue("CONNECTION", "SERVER");
+                 var database = _configService.GetValue("CONNECTION", "DATABASE");
+                 var user = _configService.GetValue("CONNECTION", "SQLUSER");
+                 var pass = _configService.GetValue("CONNECTION", "SQLPASSWORD");
+                 string decryptedPass = !string.IsNullOrEmpty(pass) ? GeneralUtils.Decrypt(pass) : null;
+
+                 var tables = await _repository.GetTablesAsync(server, database, user, decryptedPass);
+                 Tables.Clear();
+                 foreach(var t in tables) Tables.Add(t);
+            }
+            catch (System.Exception ex)
+            {
+                _logger.LogError("Failed to load tables", ex);
+            }
+        }
+
+        public SearchCriteria GetSearchCriteria()
+        {
+            var criteria = new SearchCriteria { Mode = SelectedMode, AnyMatch = AnyMatch };
+
+            if (SelectedMode == SearchMode.Function)
+            {
+                criteria.Value = SearchText;
+                if (IsFunctionNumber) criteria.Type = SearchType.Number;
+                else if (IsFunctionDescription) criteria.Type = SearchType.Description;
+                else if (IsFunctionCustomSql) criteria.Type = SearchType.CustomSql;
+            }
+            else if (SelectedMode == SearchMode.Totalizer)
+            {
+                criteria.Value = SearchText;
+                if (IsTotalizerNumber) criteria.Type = SearchType.Number;
+                else if (IsTotalizerDescription) criteria.Type = SearchType.Description;
+                else if (IsTotalizerCustomSql) criteria.Type = SearchType.CustomSql;
+            }
+            else if (SelectedMode == SearchMode.Field)
+            {
+                criteria.Value = SearchText;
+                if (IsFieldNumber) criteria.Type = SearchType.Number;
+                else if (IsFieldDescription) criteria.Type = SearchType.Description;
+                else if (IsFieldCustomSql) criteria.Type = SearchType.CustomSql;
+                else if (IsFieldTable)
+                {
+                    criteria.Type = SearchType.Table;
+                    criteria.Value = SelectedTable;
+                    criteria.ShowFields = ShowFields;
+                    criteria.LastTransaction = LastTransaction;
+                }
+            }
+
+            return criteria;
+        }
+    }
+}

--- a/SMS_Search_WPF/SMSSearch/ViewModels/SettingsViewModel.cs
+++ b/SMS_Search_WPF/SMSSearch/ViewModels/SettingsViewModel.cs
@@ -1,0 +1,55 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using SMS_Search.Services;
+using SMS_Search.Utils;
+using System.Windows.Controls;
+
+namespace SMS_Search.ViewModels
+{
+    public partial class SettingsViewModel : ObservableObject
+    {
+        private readonly IConfigService _config;
+        private readonly IDialogService _dialogService;
+
+        public event System.Action RequestClose;
+
+        public SettingsViewModel(IConfigService config, IDialogService dialogService)
+        {
+            _config = config;
+            _dialogService = dialogService;
+
+            Server = _config.GetValue("CONNECTION", "SERVER");
+            Database = _config.GetValue("CONNECTION", "DATABASE");
+            User = _config.GetValue("CONNECTION", "SQLUSER");
+        }
+
+        [ObservableProperty]
+        private string _server;
+
+        [ObservableProperty]
+        private string _database;
+
+        [ObservableProperty]
+        private string _user;
+
+        [RelayCommand]
+        private void Save(object parameter)
+        {
+            PasswordBox passwordBox = parameter as PasswordBox;
+
+            _config.SetValue("CONNECTION", "SERVER", Server);
+            _config.SetValue("CONNECTION", "DATABASE", Database);
+            _config.SetValue("CONNECTION", "SQLUSER", User);
+
+            if (passwordBox != null && !string.IsNullOrEmpty(passwordBox.Password))
+            {
+                string encrypted = GeneralUtils.Encrypt(passwordBox.Password);
+                _config.SetValue("CONNECTION", "SQLPASSWORD", encrypted);
+            }
+
+            _config.Save();
+            _dialogService.ShowMessage("Settings saved. You may need to restart or reload tables.", "Settings");
+            RequestClose?.Invoke();
+        }
+    }
+}

--- a/SMS_Search_WPF/SMSSearch/Views/ResultsView.xaml
+++ b/SMS_Search_WPF/SMSSearch/Views/ResultsView.xaml
@@ -1,0 +1,43 @@
+<UserControl x:Class="SMS_Search.Views.ResultsView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:vm="clr-namespace:SMS_Search.ViewModels"
+             xmlns:conv="clr-namespace:SMS_Search.Converters"
+             mc:Ignorable="d"
+             d:DataContext="{d:DesignInstance Type=vm:ResultsViewModel}"
+             d:DesignHeight="300" d:DesignWidth="400">
+    <UserControl.Resources>
+        <conv:BoolToVisibilityConverter x:Key="BoolToVis"/>
+    </UserControl.Resources>
+
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
+        <TextBlock Text="{Binding StatusText}" Margin="5" FontWeight="Bold"/>
+
+        <DataGrid Grid.Row="1" ItemsSource="{Binding SearchResults}"
+                  AutoGenerateColumns="True"
+                  IsReadOnly="True"
+                  SelectionMode="Extended"
+                  EnableRowVirtualization="True"
+                  VirtualizingPanel.IsVirtualizing="True"
+                  VirtualizingPanel.VirtualizationMode="Recycling">
+            <DataGrid.ContextMenu>
+                <ContextMenu>
+                    <MenuItem Header="Export to CSV" Command="{Binding ExportCsvCommand}"/>
+                    <MenuItem Header="Export to JSON" Command="{Binding ExportJsonCommand}"/>
+                    <MenuItem Header="Export to Excel XML" Command="{Binding ExportExcelCommand}"/>
+                </ContextMenu>
+            </DataGrid.ContextMenu>
+        </DataGrid>
+
+        <ProgressBar Grid.Row="2" IsIndeterminate="True" Height="10"
+                     Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"/>
+    </Grid>
+</UserControl>

--- a/SMS_Search_WPF/SMSSearch/Views/ResultsView.xaml.cs
+++ b/SMS_Search_WPF/SMSSearch/Views/ResultsView.xaml.cs
@@ -1,0 +1,12 @@
+using System.Windows.Controls;
+
+namespace SMS_Search.Views
+{
+    public partial class ResultsView : UserControl
+    {
+        public ResultsView()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/SMS_Search_WPF/SMSSearch/Views/SearchView.xaml
+++ b/SMS_Search_WPF/SMSSearch/Views/SearchView.xaml
@@ -1,0 +1,82 @@
+<UserControl x:Class="SMS_Search.Views.SearchView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:local="clr-namespace:SMS_Search.Views"
+             xmlns:vm="clr-namespace:SMS_Search.ViewModels"
+             xmlns:conv="clr-namespace:SMS_Search.Converters"
+             mc:Ignorable="d"
+             d:DataContext="{d:DesignInstance Type=vm:SearchViewModel}"
+             d:DesignHeight="300" d:DesignWidth="400">
+    <UserControl.Resources>
+        <conv:BoolToVisibilityConverter x:Key="BoolToVis"/>
+        <conv:BoolToVisibilityConverter x:Key="BoolToCollapsed" Invert="True"/>
+    </UserControl.Resources>
+
+    <Grid>
+        <TabControl SelectedIndex="{Binding SelectedMode, Mode=TwoWay}">
+            <TabItem Header="Function">
+                <StackPanel Margin="10">
+                    <StackPanel.Resources>
+                        <Style TargetType="RadioButton">
+                            <Setter Property="Margin" Value="0,2,0,2"/>
+                        </Style>
+                    </StackPanel.Resources>
+                    <RadioButton Content="Number" IsChecked="{Binding IsFunctionNumber}" GroupName="FctType"/>
+                    <RadioButton Content="Description" IsChecked="{Binding IsFunctionDescription}" GroupName="FctType"/>
+                    <RadioButton Content="Custom SQL" IsChecked="{Binding IsFunctionCustomSql}" GroupName="FctType"/>
+
+                    <TextBox Text="{Binding SearchText, UpdateSourceTrigger=PropertyChanged}" Margin="0,10,0,0" Height="25"/>
+                    <CheckBox Content="Any Match (contains)" IsChecked="{Binding AnyMatch}" Margin="0,5,0,0"/>
+                </StackPanel>
+            </TabItem>
+            <TabItem Header="Totalizer">
+                <StackPanel Margin="10">
+                    <StackPanel.Resources>
+                        <Style TargetType="RadioButton">
+                            <Setter Property="Margin" Value="0,2,0,2"/>
+                        </Style>
+                    </StackPanel.Resources>
+                    <RadioButton Content="Number" IsChecked="{Binding IsTotalizerNumber}" GroupName="TlzType"/>
+                    <RadioButton Content="Description" IsChecked="{Binding IsTotalizerDescription}" GroupName="TlzType"/>
+                    <RadioButton Content="Custom SQL" IsChecked="{Binding IsTotalizerCustomSql}" GroupName="TlzType"/>
+
+                    <TextBox Text="{Binding SearchText, UpdateSourceTrigger=PropertyChanged}" Margin="0,10,0,0" Height="25"/>
+                    <CheckBox Content="Any Match (contains)" IsChecked="{Binding AnyMatch}" Margin="0,5,0,0"/>
+                </StackPanel>
+            </TabItem>
+            <TabItem Header="Fields">
+                <StackPanel Margin="10">
+                    <StackPanel.Resources>
+                        <Style TargetType="RadioButton">
+                            <Setter Property="Margin" Value="0,2,0,2"/>
+                        </Style>
+                    </StackPanel.Resources>
+                    <RadioButton Content="Number" IsChecked="{Binding IsFieldNumber}" GroupName="FldType"/>
+                    <RadioButton Content="Description" IsChecked="{Binding IsFieldDescription}" GroupName="FldType"/>
+                    <RadioButton Content="Table" IsChecked="{Binding IsFieldTable}" GroupName="FldType"/>
+                    <RadioButton Content="Custom SQL" IsChecked="{Binding IsFieldCustomSql}" GroupName="FldType"/>
+
+                    <ComboBox ItemsSource="{Binding Tables}" SelectedItem="{Binding SelectedTable}"
+                              Visibility="{Binding IsFieldTable, Converter={StaticResource BoolToVis}}"
+                              Margin="0,5,0,0" Height="25"
+                              DropDownOpened="ComboBox_DropDownOpened"/>
+
+                    <TextBox Text="{Binding SearchText, UpdateSourceTrigger=PropertyChanged}"
+                             Visibility="{Binding IsFieldTable, Converter={StaticResource BoolToCollapsed}}"
+                             Margin="0,10,0,0" Height="25"/>
+
+                    <StackPanel Orientation="Horizontal" Margin="0,5,0,0"
+                                Visibility="{Binding IsFieldTable, Converter={StaticResource BoolToVis}}">
+                        <RadioButton Content="Show Fields" IsChecked="{Binding ShowFields}" GroupName="FldAction"/>
+                        <RadioButton Content="Show Records" IsChecked="{Binding ShowRecords}" GroupName="FldAction" Margin="10,0,0,0"/>
+                        <CheckBox Content="Last Transaction" IsChecked="{Binding LastTransaction}" Margin="10,0,0,0"/>
+                    </StackPanel>
+
+                    <CheckBox Content="Any Match (contains)" IsChecked="{Binding AnyMatch}" Margin="0,5,0,0"/>
+                </StackPanel>
+            </TabItem>
+        </TabControl>
+    </Grid>
+</UserControl>

--- a/SMS_Search_WPF/SMSSearch/Views/SearchView.xaml.cs
+++ b/SMS_Search_WPF/SMSSearch/Views/SearchView.xaml.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Windows.Controls;
+using SMS_Search.ViewModels;
+
+namespace SMS_Search.Views
+{
+    public partial class SearchView : UserControl
+    {
+        public SearchView()
+        {
+            InitializeComponent();
+        }
+
+        private void ComboBox_DropDownOpened(object sender, EventArgs e)
+        {
+            if (DataContext is SearchViewModel vm)
+            {
+                vm.LoadTablesCommand.Execute(null);
+            }
+        }
+    }
+}

--- a/SMS_Search_WPF/SMSSearch/Views/SettingsWindow.xaml
+++ b/SMS_Search_WPF/SMSSearch/Views/SettingsWindow.xaml
@@ -1,0 +1,27 @@
+<Window x:Class="SMS_Search.Views.SettingsWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:vm="clr-namespace:SMS_Search.ViewModels"
+        mc:Ignorable="d"
+        Title="Settings" Height="300" Width="400"
+        WindowStartupLocation="CenterOwner">
+    <StackPanel Margin="20">
+        <Label Content="Server:"/>
+        <TextBox Text="{Binding Server}" Margin="0,0,0,10"/>
+
+        <Label Content="Database:"/>
+        <TextBox Text="{Binding Database}" Margin="0,0,0,10"/>
+
+        <Label Content="User:"/>
+        <TextBox Text="{Binding User}" Margin="0,0,0,10"/>
+
+        <Label Content="Password:"/>
+        <PasswordBox x:Name="txtPassword" Margin="0,0,0,20"/>
+
+        <Button Content="Save" Command="{Binding SaveCommand}"
+                CommandParameter="{Binding ElementName=txtPassword}"
+                HorizontalAlignment="Right" Padding="20,5"/>
+    </StackPanel>
+</Window>

--- a/SMS_Search_WPF/SMSSearch/Views/SettingsWindow.xaml.cs
+++ b/SMS_Search_WPF/SMSSearch/Views/SettingsWindow.xaml.cs
@@ -1,0 +1,16 @@
+using System;
+using System.Windows;
+using SMS_Search.ViewModels;
+
+namespace SMS_Search.Views
+{
+    public partial class SettingsWindow : Window
+    {
+        public SettingsWindow(SettingsViewModel viewModel)
+        {
+            InitializeComponent();
+            DataContext = viewModel;
+            viewModel.RequestClose += () => this.Close();
+        }
+    }
+}


### PR DESCRIPTION
Converted the existing WinForms solution to a new WPF MVVM project targeting .NET 10.

Key changes:
- Created a new solution `SMSSearch.sln` in `SMS_Search_WPF` directory.
- Implemented MVVM architecture using `CommunityToolkit.Mvvm`.
- Ported `DataRepository` to use `Dapper` with dependency injection.
- Reimplemented `VirtualGridContext` to support efficient server-side paging and filtering.
- Created `VirtualizingCollection` to bind virtualized data to WPF `DataGrid`.
- Implemented "Settings" dialog for database configuration.
- Implemented "Listener" mode with global hotkeys using `IHotkeyService`.
- Added support for Single File publishing.
- Ported utility classes (`ConfigManager`, `LoggerService`, `GeneralUtils`, `HotkeyUtils`).

---
*PR created automatically by Jules for task [8794838924220607562](https://jules.google.com/task/8794838924220607562) started by @Rapscallion0*