### PR TITLE
Prompt for GitHub Release on Publish with Zipped Artifact

### DIFF
--- a/SMS Search.csproj
+++ b/SMS Search.csproj
@@ -75,8 +75,8 @@
     <Move SourceFiles="$(OutputPath)$(AssemblyName).Merged.exe" DestinationFiles="$(OutputPath)$(AssemblyName).exe" OverwriteReadOnlyFiles="true" />
   </Target>
 
-  <Target Name="PostBuildRelease" AfterTargets="PostBuildEvent" Condition="'$(Configuration)' == 'Release' And '$(OS)' == 'Windows_NT'">
-     <Exec Command="powershell.exe -ExecutionPolicy Bypass -NoProfile -NonInteractive -File &quot;$(MSBuildProjectDirectory)\Scripts\publish_release.ps1&quot; -AssemblyInfoPath &quot;$(MSBuildProjectDirectory)\Properties\AssemblyInfo.cs&quot; -ExePath &quot;$(TargetPath)&quot;" />
+  <Target Name="PublishToGitHub" AfterTargets="Publish" Condition="'$(OS)' == 'Windows_NT'">
+     <Exec Command="powershell.exe -ExecutionPolicy Bypass -NoProfile -NonInteractive -File &quot;$(MSBuildProjectDirectory)\Scripts\publish_release.ps1&quot; -AssemblyInfoPath &quot;$(MSBuildProjectDirectory)\Properties\AssemblyInfo.cs&quot; -InputPath &quot;$(PublishDir).&quot;" />
   </Target>
 
   <Target Name="PostBuildServiceRestore" AfterTargets="Build" Condition="'$(OS)' == 'Windows_NT'">


### PR DESCRIPTION
This change updates the build process to prompt for a GitHub release upload only when using the "Publish" feature, rather than on every Release build. It also changes the upload artifact to be a zip file (`SMS_Search.zip`) containing the executable, instead of the executable itself. The PowerShell script was enhanced to support manual execution against a directory.

---
*PR created automatically by Jules for task [12952706953268348653](https://jules.google.com/task/12952706953268348653) started by @Rapscallion0*